### PR TITLE
Fix use of deprecated parser behavior

### DIFF
--- a/gpxpy/parser.py
+++ b/gpxpy/parser.py
@@ -225,7 +225,7 @@ class GPXParser:
     def __parse_dom(self):
 
         node = self.xml_parser.get_first_child(name='gpx')
-        if not node:
+        if node is None:
             raise mod_gpx.GPXException('Document must have a `gpx` root node.')
 
         for node in self.xml_parser.get_children(node):


### PR DESCRIPTION
gpxpy/parser.py:228 uses a test for boolean falseness to check if an xml
node is not found:

"""
  if not node:
"""

With python-lxml 2.3.5, this produces a warning:
./gpxpy/gpxpy/parser.py:228: FutureWarning: The behavior of this method
will change in future versions. Use specific 'len(elem)' or 'elem is not
None' test instead.

This patch just changes the test to:
"""
  if node is None:
"""

Unit tests pass.
