### PR TITLE
Ignore empty track segment when calculating bounds

### DIFF
--- a/gpxpy/gpx.py
+++ b/gpxpy/gpx.py
@@ -418,13 +418,13 @@ class GPXTrack:
         for track_segment in self.segments:
             bounds = track_segment.get_bounds()
 
-            if not mod_utils.is_numeric(min_lat) or bounds.min_latitude < min_lat:
+            if not mod_utils.is_numeric(min_lat) or (bounds.min_latitude and bounds.min_latitude < min_lat):
                 min_lat = bounds.min_latitude
-            if not mod_utils.is_numeric(max_lat) or bounds.max_latitude > max_lat:
+            if not mod_utils.is_numeric(max_lat) or (bounds.max_latitude and bounds.max_latitude > max_lat):
                 max_lat = bounds.max_latitude
-            if not mod_utils.is_numeric(min_lon) or bounds.min_longitude < min_lon:
+            if not mod_utils.is_numeric(min_lon) or (bounds.min_longitude and bounds.min_longitude < min_lon):
                 min_lon = bounds.min_longitude
-            if not mod_utils.is_numeric(max_lon) or bounds.max_longitude > max_lon:
+            if not mod_utils.is_numeric(max_lon) or (bounds.max_longitude and bounds.max_longitude > max_lon):
                 max_lon = bounds.max_longitude
 
         return Bounds(min_lat, max_lat, min_lon, max_lon)

--- a/test.py
+++ b/test.py
@@ -1149,6 +1149,12 @@ class LxmlTests(mod_unittest.TestCase):
         self.assertTrue(uphill is not None)
         self.assertTrue(downhill is not None)
 
+    def test_track_with_empty_segment(self):
+        with open('test_files/track-with-empty-segment.gpx') as f:
+            gpx = mod_gpxpy.parse(f, parser=self.get_parser_type())
+            self.assertIsNotNone(gpx.tracks[0].get_bounds().min_latitude)
+            self.assertIsNotNone(gpx.tracks[0].get_bounds().min_longitude)
+
 class MinidomTests(LxmlTests):
 
     def get_parser_type(self):

--- a/test_files/track-with-empty-segment.gpx
+++ b/test_files/track-with-empty-segment.gpx
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="utf-8" standalone="no"?>
+<gpx xmlns="http://www.topografix.com/GPX/1/1" xmlns:tc2="http://www.garmin.com/xmlschemas/TrainingCenterDatabase/v2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:tp1="http://www.garmin.com/xmlschemas/TrackPointExtension/v1" version="1.1" creator="TC2 to GPX11 XSLT stylesheet" xsi:schemaLocation="http://www.topografix.com/GPX/1/1 http://www.topografix.com/GPX/1/1/gpx.xsd http://www.garmin.com/xmlschemas/TrackPointExtension/v1 http://www.garmin.com/xmlschemas/TrackPointExtensionv1.xsd">
+    <trk>
+        <name>2013-07-06T14:59:00Z</name>
+        <trkseg>
+            <trkpt lat="50.7772126" lon="6.0819695">
+                <ele>191.5999756</ele>
+                <time>2013-07-06T17:26:26Z</time>
+            </trkpt>
+            <trkpt lat="50.7773346" lon="6.0821333">
+                <ele>191.5999756</ele>
+                <time>2013-07-06T17:26:30Z</time>
+            </trkpt>
+            <trkpt lat="50.7774666" lon="6.0823426">
+                <ele>191.5999756</ele>
+                <time>2013-07-06T17:26:35Z</time>
+            </trkpt>
+            <trkpt lat="50.7776203" lon="6.0826253">
+                <ele>191.5999756</ele>
+                <time>2013-07-06T17:26:44Z</time>
+            </trkpt>
+            <trkpt lat="50.7776910" lon="6.0826803">
+                <ele>191.5999756</ele>
+                <time>2013-07-06T17:26:49Z</time>
+            </trkpt>
+            <trkpt lat="50.7777283" lon="6.0827079">
+                <ele>191.5999756</ele>
+                <time>2013-07-06T17:26:57Z</time>
+            </trkpt>
+            <trkpt lat="50.7777341" lon="6.0827095">
+                <ele>191.5999756</ele>
+                <time>2013-07-06T17:27:15Z</time>
+            </trkpt>
+            <trkpt lat="50.7776789" lon="6.0827233">
+                <ele>191.5999756</ele>
+                <time>2013-07-06T17:27:41Z</time>
+            </trkpt>
+            <trkpt lat="50.7776715" lon="6.0827203">
+                <ele>191.5999756</ele>
+                <time>2013-07-06T17:27:42Z</time>
+            </trkpt>
+        </trkseg>
+        <trkseg></trkseg>
+    </trk>
+</gpx>


### PR DESCRIPTION
In situations where an empty track segment occurs at the end of a
track file the bounding box calculation would produce None values
for the minimum latitude and longitude because None < x evaluates
to true. By explicitely checking if the track segment has a valid
bounding box this can be circumvented easily.
