### PR TITLE
Include AutoRoutepoint

### DIFF
--- a/gpxpy/parser.py
+++ b/gpxpy/parser.py
@@ -338,6 +338,15 @@ class GPXParser:
                 route_point = self._parse_route_point(child_node)
                 route.points.append(route_point)
 
+                # append AutoroutePoints to route_points
+                extensions_node = self.xml_parser.get_first_child(child_node, 'extensions')
+                route_point_extension = self.xml_parser.get_first_child(extensions_node, 'RoutePointExtension')
+                rpt_nodes = self.xml_parser.get_children(route_point_extension)
+                for rpt_node in rpt_nodes:
+                    if self.xml_parser.get_node_name(rpt_node) == 'rpt':
+                        auto_route_point = self._parse_route_point(rpt_node)
+                        route.points.append(auto_route_point)
+
         return route
 
     def _parse_route_point(self, node):


### PR DESCRIPTION
Hi
I noticed that when I generate a gpx with mapsource and use autorouting, some routepoints can also contain autoroutepoints. They are necessary to have a "full" route at the end. Therefore I just add them to the route similar to the routepoints.

The following is an example for a routepoint including autoroutepoints:
    <rtept lat="47.360644340515137" lon="8.529253005981445">
      <time>2013-07-14T13:08:27Z</time>
      <name>Schulhausstrasse and Brglistrasse and Joachim-Hefti-Weg Ft</name>
      <cmt>Schulhausstrasse and Brglistrasse and Joachim-Hefti-Weg Ft</cmt>
      <desc>Schulhausstrasse and Brglistrasse and Joachim-Hefti-Weg Ft</desc>
      <sym>Waypoint</sym>
      <extensions>
        <gpxx:RoutePointExtension xmlns:gpxx="http://www.garmin.com/xmlschemas/GpxExtensions/v3">
          gpxx:Subclass06007F6CC5030D00FC010F210600BEADB410/gpxx:Subclass
          <gpxx:rpt lat="47.360644340515137" lon="8.529253005981445">
            gpxx:Subclass06007F6CC50372F501002116000053000000/gpxx:Subclass
          /gpxx:rpt
          <gpxx:rpt lat="47.360644340515137" lon="8.529253005981445">
            gpxx:Subclass13007F6CC503E9C311001F001E0062A42000/gpxx:Subclass
          /gpxx:rpt
          <gpxx:rpt lat="47.360086441040039" lon="8.529231548309326"/>
          <gpxx:rpt lat="47.359914779663086" lon="8.52914571762085">
            gpxx:Subclass06007F6CC5032DBF08001F001E00F0AC1C00/gpxx:Subclass
          /gpxx:rpt
          <gpxx:rpt lat="47.359292507171631" lon="8.529231548309326">
            gpxx:Subclass06007F6CC5032C1705001F061E00E8801000/gpxx:Subclass
          /gpxx:rpt
          <gpxx:rpt lat="47.359271049499512" lon="8.529531955718994"/>
          <gpxx:rpt lat="47.359271049499512" lon="8.529767990112305">
            gpxx:Subclass07007F6CC50340470A001F021E00CB800400/gpxx:Subclass
          /gpxx:rpt
          <gpxx:rpt lat="47.359142303466797" lon="8.529746532440186">
            gpxx:Subclass13007F6CC5031D730E001F021E004E861200/gpxx:Subclass
          /gpxx:rpt
          <gpxx:rpt lat="47.359163761138916" lon="8.529531955718994"/>
          <gpxx:rpt lat="47.359142303466797" lon="8.529467582702637"/>
          <gpxx:rpt lat="47.359035015106201" lon="8.529424667358398"/>
          <gpxx:rpt lat="47.358970642089844" lon="8.529403209686279"/>
          <gpxx:rpt lat="47.358954297378659" lon="8.529408490285277">
            gpxx:Subclass13007F6CC5031D730E002117000012001200/gpxx:Subclass
          /gpxx:rpt
        /gpxx:RoutePointExtension
      </extensions>
    </rtept>
