### PR TITLE
Fix get_speed function in GPXTrackSegment

### DIFF
--- a/gpxpy/gpx.py
+++ b/gpxpy/gpx.py
@@ -831,8 +831,8 @@ class GPXTrackSegment:
         #mod_logging.debug('previous: %s' % previous_point)
         #mod_logging.debug('next: %s' % next_point)
 
-        speed_1 = point.speed(previous_point)
-        speed_2 = point.speed(next_point)
+        speed_1 = point.speed_between(previous_point)
+        speed_2 = point.speed_between(next_point)
 
         if speed_1:
             speed_1 = abs(speed_1)


### PR DESCRIPTION
Should the speed calculation call speed_between() instead of speed(), shouldn't it?
