### PR TITLE
Don't return None when speed between points is zero

### DIFF
--- a/gpxpy/gpx.py
+++ b/gpxpy/gpx.py
@@ -483,7 +483,7 @@ class GPXTrackPoint(mod_geo.Location):
         if not length:
             length = self.distance_2d(track_point)
 
-        if not seconds or length is not None:
+        if not seconds or length is None:
             return None
 
         return length / float(seconds)


### PR DESCRIPTION
When calculating the speed between tracking point currently None is returned when the 2 points have the same longtitude and latitude.  Even if the time of the tracking points differ.  This seems incorrect to me, I think the correct behavior is to return a float of 0.0.  (btw: tests still run ok after the change)
