### PR TITLE
Rewrote datetime parsing code to use isodate

### DIFF
--- a/gpxpy/gpx.py
+++ b/gpxpy/gpx.py
@@ -33,14 +33,6 @@ from . import gpxfield as mod_gpxfield
 # GPX date format to be used when writing the GPX output:
 DATE_FORMAT = '%Y-%m-%dT%H:%M:%SZ'
 
-# GPX date format(s) used for parsing. The T between date and time and Z after
-# time are allowed, too:
-DATE_FORMATS = [
-    '%Y-%m-%d %H:%M:%S',
-    '%Y-%m-%d %H:%M:%S.%f',
-    #'%Y-%m-%d %H:%M:%S%z',
-    #'%Y-%m-%d %H:%M:%S.%f%z',
-]
 # Used in smoothing, sum must be 1:
 SMOOTHING_RATIO = (0.4, 0.2, 0.4)
 

--- a/gpxpy/gpx.py
+++ b/gpxpy/gpx.py
@@ -30,9 +30,6 @@ from . import utils as mod_utils
 from . import geo as mod_geo
 from . import gpxfield as mod_gpxfield
 
-# GPX date format to be used when writing the GPX output:
-DATE_FORMAT = '%Y-%m-%dT%H:%M:%SZ'
-
 # Used in smoothing, sum must be 1:
 SMOOTHING_RATIO = (0.4, 0.2, 0.4)
 

--- a/gpxpy/gpxfield.py
+++ b/gpxpy/gpxfield.py
@@ -45,11 +45,7 @@ class IntConverter:
 
 class TimeConverter:
     def from_string(self, string):
-        #try:
         return isodate.parse_datetime(string)
-        #except:
-        #    # silently fail on error
-        #    return
 
     def to_string(self, time):
         return isodate.datetime_isoformat(time) if time else None

--- a/gpxpy/gpxfield.py
+++ b/gpxpy/gpxfield.py
@@ -26,22 +26,6 @@ class GPXFieldTypeConverter:
         self.to_string = to_string
 
 
-def parse_time(string):
-    from . import gpx as mod_gpx
-    if not string:
-        return None
-    if 'T' in string:
-        string = string.replace('T', ' ')
-    if 'Z' in string:
-        string = string.replace('Z', '')
-    for date_format in mod_gpx.DATE_FORMATS:
-        try:
-            return mod_datetime.datetime.strptime(string, date_format)
-        except ValueError as e:
-            pass
-    raise GPXException('Invalid time: %s' % string)
-
-
 # ----------------------------------------------------------------------------------------------------
 # Type converters used to convert from/to the string in the XML:
 # ----------------------------------------------------------------------------------------------------

--- a/gpxpy/gpxfield.py
+++ b/gpxpy/gpxfield.py
@@ -15,9 +15,9 @@
 # limitations under the License.
 
 import inspect as mod_inspect
-import datetime as mod_datetime
-
+import isodate
 from . import utils as mod_utils
+
 
 
 class GPXFieldTypeConverter:
@@ -45,22 +45,14 @@ class IntConverter:
 
 class TimeConverter:
     def from_string(self, string):
-        from . import gpx as mod_gpx
-        if not string:
-            return None
-        if 'T' in string:
-            string = string.replace('T', ' ')
-        if 'Z' in string:
-            string = string.replace('Z', '')
-        for date_format in mod_gpx.DATE_FORMATS:
-            try:
-                return mod_datetime.datetime.strptime(string, date_format)
-            except ValueError as e:
-                pass
-        return None
+        #try:
+        return isodate.parse_datetime(string)
+        #except:
+        #    # silently fail on error
+        #    return
+
     def to_string(self, time):
-        from . import gpx as mod_gpx
-        return time.strftime(mod_gpx.DATE_FORMAT) if time else None
+        return isodate.datetime_isoformat(time) if time else None
 
 
 INT_TYPE = IntConverter()

--- a/setup.py
+++ b/setup.py
@@ -14,9 +14,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import distutils.core as mod_distutilscore
+from setuptools import setup
 
-mod_distutilscore.setup(
+setup(
     name='gpxpy',
     version='0.9.8',
     description='GPX file parser and GPS track manipulation library',
@@ -25,6 +25,7 @@ mod_distutilscore.setup(
     author_email='tkrajina@gmail.com',
     url='http://www.trackprofiler.com/gpxpy/index.html',
     packages=['gpxpy',],
+    install_requires=['lxml', 'isodate'],
     classifiers=[
         "Programming Language :: Python",
         "Programming Language :: Python :: 2",

--- a/test.py
+++ b/test.py
@@ -50,6 +50,7 @@ import gpxpy.parser as mod_parser
 import gpxpy.geo as mod_geo
 
 from gpxpy.utils import make_str
+from isodate.tzinfo import UTC
 
 PYTHON_VERSION = mod_sys.version.split(' ')[0]
 
@@ -1513,21 +1514,19 @@ class AbstractTests:
         tc = mod_gpxfield.TimeConverter()
         timestamps = [
             '2001-10-26T21:32:52',
-            #'2001-10-26T21:32:52+0200',
+            '2001-10-26T21:32:52+0200',
             '2001-10-26T19:32:52Z',
-            #'2001-10-26T19:32:52+00:00',
+            '2001-10-26T19:32:52+00:00',
             #'-2001-10-26T21:32:52',
             '2001-10-26T21:32:52.12679',
             '2001-10-26T21:32:52',
-            #'2001-10-26T21:32:52+02:00',
+            '2001-10-26T21:32:52+02:00',
             '2001-10-26T19:32:52Z',
-            #'2001-10-26T19:32:52+00:00',
+            '2001-10-26T19:32:52+00:00',
             #'-2001-10-26T21:32:52',
             '2001-10-26T21:32:52.12679',
         ]
-        timestamps_without_tz = list(map(lambda x: x.replace('T', ' ').replace('Z', ''), timestamps))
-        for t in timestamps_without_tz:
-            timestamps.append(t)
+
         for timestamp in timestamps:
             print('Parsing: %s' % timestamp)
             self.assertTrue(tc.from_string(timestamp) is not None)
@@ -1675,7 +1674,9 @@ class AbstractTests:
                 self.assertEquals(gpx.link_text, 'example urlname')
                 self.assertEquals(get_dom_node(dom, 'gpx/urlname').firstChild.nodeValue, 'example urlname')
 
-                self.assertEquals(gpx.time, mod_datetime.datetime(2013, 1, 1, 12, 0))
+                # This has two different possible values, and only one is TZ-aware
+                # Remove the tzinfo from the output of one.
+                self.assertEquals(gpx.time.replace(tzinfo=None), mod_datetime.datetime(2013, 1, 1, 12, 0))
                 self.assertTrue(get_dom_node(dom, 'gpx/time').firstChild.nodeValue in ('2013-01-01T12:00:00Z', '2013-01-01T12:00:00'))
 
                 self.assertEquals(gpx.keywords, 'example keywords')
@@ -1700,7 +1701,7 @@ class AbstractTests:
                 self.assertEquals(gpx.waypoints[0].elevation, 75.1)
                 self.assertEquals(get_dom_node(dom, 'gpx/wpt[0]/ele').firstChild.nodeValue, '75.1')
 
-                self.assertEquals(gpx.waypoints[0].time, mod_datetime.datetime(2013, 1, 2, 2, 3))
+                self.assertEquals(gpx.waypoints[0].time, mod_datetime.datetime(2013, 1, 2, 2, 3, tzinfo=UTC))
                 self.assertEquals(get_dom_node(dom, 'gpx/wpt[0]/time').firstChild.nodeValue, '2013-01-02T02:03:00Z')
 
                 self.assertEquals(gpx.waypoints[0].magnetic_variation, 1.1)
@@ -1761,7 +1762,7 @@ class AbstractTests:
                 self.assertEquals(gpx.routes[0].points[0].elevation, 75.1)
                 self.assertEquals(get_dom_node(dom, 'gpx/rte[0]/rtept[0]/ele').firstChild.nodeValue, '75.1')
 
-                self.assertEquals(gpx.routes[0].points[0].time, mod_datetime.datetime(2013, 1, 2, 2, 3, 3))
+                self.assertEquals(gpx.routes[0].points[0].time, mod_datetime.datetime(2013, 1, 2, 2, 3, 3, tzinfo=UTC))
                 self.assertEquals(get_dom_node(dom, 'gpx/rte[0]/rtept[0]/time').firstChild.nodeValue, '2013-01-02T02:03:03Z')
 
                 self.assertEquals(gpx.routes[0].points[0].magnetic_variation, 1.2)
@@ -1870,7 +1871,7 @@ class AbstractTests:
                 self.assertEquals(gpx.tracks[0].segments[0].points[0].elevation, 11.1)
                 self.assertEquals(get_dom_node(dom, 'gpx/trk[0]/trkseg[0]/trkpt[0]/ele').firstChild.nodeValue, '11.1')
 
-                self.assertEquals(gpx.tracks[0].segments[0].points[0].time, mod_datetime.datetime(2013, 1, 1, 12, 0, 4))
+                self.assertEquals(gpx.tracks[0].segments[0].points[0].time.replace(tzinfo=None), mod_datetime.datetime(2013, 1, 1, 12, 0, 4))
                 self.assertTrue(get_dom_node(dom, 'gpx/trk[0]/trkseg[0]/trkpt[0]/time').firstChild.nodeValue in ('2013-01-01T12:00:04Z', '2013-01-01T12:00:04'))
 
                 self.assertEquals(gpx.tracks[0].segments[0].points[0].magnetic_variation, 12)
@@ -2019,7 +2020,7 @@ class AbstractTests:
                 self.assertEquals(gpx.waypoints[0].elevation, 75.1)
                 self.assertEquals(get_dom_node(dom, 'gpx/wpt[0]/ele').firstChild.nodeValue, '75.1')
 
-                self.assertEquals(gpx.waypoints[0].time, mod_datetime.datetime(2013, 1, 2, 2, 3))
+                self.assertEquals(gpx.waypoints[0].time, mod_datetime.datetime(2013, 1, 2, 2, 3, tzinfo=UTC))
                 self.assertEquals(get_dom_node(dom, 'gpx/wpt[0]/time').firstChild.nodeValue, '2013-01-02T02:03:00Z')
 
                 self.assertEquals(gpx.waypoints[0].magnetic_variation, 1.1)
@@ -2120,7 +2121,7 @@ class AbstractTests:
                 self.assertEquals(gpx.routes[0].points[0].elevation, 75.1)
                 self.assertEquals(get_dom_node(dom, 'gpx/rte[0]/rtept[0]/ele').firstChild.nodeValue, '75.1')
 
-                self.assertEquals(gpx.routes[0].points[0].time, mod_datetime.datetime(2013, 1, 2, 2, 3, 3))
+                self.assertEquals(gpx.routes[0].points[0].time, mod_datetime.datetime(2013, 1, 2, 2, 3, 3, tzinfo=UTC))
                 self.assertEquals(get_dom_node(dom, 'gpx/rte[0]/rtept[0]/time').firstChild.nodeValue, '2013-01-02T02:03:03Z')
 
                 self.assertEquals(gpx.routes[0].points[0].magnetic_variation, 1.2)

--- a/test.py
+++ b/test.py
@@ -1510,6 +1510,7 @@ class AbstractTests:
         self.assertEquals(seconds, 60 * 60 * 24 + 60)
 
     def test_parse_time(self):
+        tc = mod_gpxfield.TimeConverter()
         timestamps = [
             '2001-10-26T21:32:52',
             #'2001-10-26T21:32:52+0200',
@@ -1529,7 +1530,11 @@ class AbstractTests:
             timestamps.append(t)
         for timestamp in timestamps:
             print('Parsing: %s' % timestamp)
-            self.assertTrue(mod_gpxfield.parse_time(timestamp) is not None)
+            self.assertTrue(tc.from_string(timestamp) is not None)
+
+        # FIXME: Check that the values returned are actually those that are
+        # expected, not that the parse was successful.  These tests are
+        # incomplete.
 
     def test_get_location_at(self):
         gpx = mod_gpx.GPX()


### PR DESCRIPTION
According to the specification of GPX, the only format for datetime values is xsd:dateTime, which is an ISO 8601 date format.  Things like ISO8601 "without T" which is included in your tests aren't actually valid for GPX files at all... so I have removed this.  If there's a piece of software that produces files in this way, you may want to look at using an [attitude readjustment tool](https://en.wikipedia.org/wiki/Hammer) on the developer of that software. :)

I'm using the `isodate` library as it is more fully featured than the existing code was, supporting such things as being TZ-aware, and not trying to strip out timezone information that is there.  I've also removed the unused `parse_time` function that was used in unit testing, but never actually used when parsing a GPX file.

There's still some more work to be done, like making the datetime parsing tests actually check the output of that function, instead of just checking if the function failed to execute.  But given it's using a third-party library that has unit tests, this may be entirely redundant.