### PR TITLE
Fix uphill/downhill calculation on missing values

### DIFF
--- a/gpxpy/geo.py
+++ b/gpxpy/geo.py
@@ -138,7 +138,7 @@ def calculate_uphill_downhill(elevations):
     def __filter(n):
         current_ele = elevations[n]
         if current_ele is None:
-            return False
+            return None
         if 0 < n < size - 1:
             previous_ele = elevations[n-1]
             next_ele = elevations[n+1]
@@ -151,7 +151,7 @@ def calculate_uphill_downhill(elevations):
     uphill, downhill = 0., 0.
 
     for n, elevation in enumerate(smoothed_elevations):
-        if n > 0 and elevation is not None and smoothed_elevations is not None:
+        if n > 0 and elevation is not None and smoothed_elevations[n-1] is not None:
             d = elevation - smoothed_elevations[n-1]
             if d > 0:
                 uphill += d


### PR DESCRIPTION
When reading a GPX file with two <ele> dropouts (None), I noticed that the uphill/downhill calculation returns very high values. The PR fixes that basically.

All in all, the calculated values still seem a little high for a random tour picked from [here](http://www.gps-tour.info/de/touren/download.106012.html?tour_action=download&format=orig&version=) - it is ~200m away from the value calculated by the GPS portal. But as long we cannot see what they did to get their values, its just a guess which result is more correct, anyway ;-)