### PR TITLE
Avoid division by zero in gpx files with no points

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,5 @@ nosetests.xml
 .idea
 
 pyenv/*
+validation_gpx10.gpx
+validation_gpx11.gpx

--- a/gpxpy/gpx.py
+++ b/gpxpy/gpx.py
@@ -165,18 +165,18 @@ class GPXBounds:
         Compute the nearest location inside this rectangle to a given location.
         Return value will be input location if it is inside the rectangle
         """
-        nearPoint=mod_geo.Location(location.latitude, location.longitude)
+        near_loc = mod_geo.Location(location.latitude, location.longitude)
         if location.latitude < self.min_latitude:
-            nearPoint.latitude = self.min_latitude
+            near_loc.latitude = self.min_latitude
         elif location.latitude > self.max_latitude:
-            nearPoint.latitude = self.max_latitude
+            near_loc.latitude = self.max_latitude
             
         if location.longitude < self.min_longitude:
-            nearPoint.longitude = self.min_longitude
+            near_loc.longitude = self.min_longitude
         elif location.longitude > self.max_longitude:
-            nearPoint.longitude = self.max_longitude
+            near_loc.longitude = self.max_longitude
             
-        return nearPoint
+        return near_loc
 
     def distance_2d(self, location):
         """

--- a/gpxpy/gpx.py
+++ b/gpxpy/gpx.py
@@ -160,6 +160,31 @@ class GPXBounds:
     def __hash__(self):
         return mod_utils.hash_object(self, self.__slots__)
 
+    def get_nearest_location(self, location):
+        """
+        Compute the nearest location inside this rectangle to a given location.
+        Return value will be input location if it is inside the rectangle
+        """
+        nearPoint=mod_geo.Location(location.latitude, location.longitude)
+        if location.latitude < self.min_latitude:
+            nearPoint.latitude = self.min_latitude
+        elif location.latitude > self.max_latitude:
+            nearPoint.latitude = self.max_latitude
+            
+        if location.longitude < self.min_longitude:
+            nearPoint.longitude = self.min_longitude
+        elif location.longitude > self.max_longitude:
+            nearPoint.longitude = self.max_longitude
+            
+        return nearPoint
+
+    def distance_2d(self, location):
+        """
+        Compute the minimum distance from this rectangle to a given location.
+        Return value will be 0. if the location is inside the rectangle
+        """
+        return location.distance_2d(self.get_nearest_location(location))
+
 
 class GPXXMLSyntaxException(GPXException):
     """


### PR DESCRIPTION
Sometimes a gpx file is used just as a collection of  waypoints, with no segments on it. In those cases, a ZeroDivisionError can be launched when computing the average distance between points.

Added methods to compute the nearest_location and the distance_2d from a bound to a given location.
Those are useful to build a fast way to determine if a location is near of a track, and to sort a bunch 
of tracks by distance to a location without calling the expensive GPXTrack.get_nearest_location(location) method, which iterates over all points of a track.