### PR TITLE
Run unit tests with coverage on Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,49 @@
+language: python
+
+# Use container-based infrastructure
+sudo: false
+
+# Those without lxml wheels first because building lxml is slow
+python:
+ - 3.5
+ - 3.2
+ - 2.7
+ - 2.6
+ - 3.4
+ - 3.3
+
+install:
+ - if [ "$TRAVIS_PYTHON_VERSION" == "2.6" ]; then wget -q -P /tmp "https://github.com/obspy/wheelhouse/raw/master/lxml-3.4.0-cp26-none-linux_x86_64.whl"; fi
+ - if [ "$TRAVIS_PYTHON_VERSION" == "2.7" ]; then wget -q -P /tmp "https://github.com/obspy/wheelhouse/raw/master/lxml-3.4.0-cp27-none-linux_x86_64.whl"; fi
+ - if [ "$TRAVIS_PYTHON_VERSION" == "3.3" ]; then wget -q -P /tmp "https://github.com/obspy/wheelhouse/raw/master/lxml-3.4.0-cp33-cp33m-linux_x86_64.whl"; fi
+ - if [ "$TRAVIS_PYTHON_VERSION" == "3.4" ]; then wget -q -P /tmp "https://github.com/obspy/wheelhouse/raw/master/lxml-3.4.0-cp34-cp34m-linux_x86_64.whl"; fi
+ - if [ "$TRAVIS_PYTHON_VERSION" == "2.6" ]; then pip install --use-wheel --no-index --find-links=/tmp lxml; fi
+ - if [ "$TRAVIS_PYTHON_VERSION" == "2.7" ]; then pip install --use-wheel --no-index --find-links=/tmp lxml; fi
+ - if [ "$TRAVIS_PYTHON_VERSION" == "3.3" ]; then pip install --use-wheel --no-index --find-links=/tmp lxml; fi
+ - if [ "$TRAVIS_PYTHON_VERSION" == "3.4" ]; then pip install --use-wheel --no-index --find-links=/tmp lxml; fi
+ - if [ "$TRAVIS_PYTHON_VERSION" == "3.2" ]; then pip install lxml; fi
+ - if [ "$TRAVIS_PYTHON_VERSION" == "3.5" ]; then pip install lxml; fi
+
+ # Coveralls 4.0 doesn't support Python 3.2
+ - if [ "$TRAVIS_PYTHON_VERSION" == "3.2" ]; then travis_retry pip install coverage==3.7.1; fi
+ - if [ "$TRAVIS_PYTHON_VERSION" != "3.2" ]; then travis_retry pip install coverage; fi
+
+ - if [ "$TRAVIS_PYTHON_VERSION" == "2.6" ]; then pip install unittest2; fi
+
+
+script:
+ - python -m unittest test
+ - coverage run --source=gpxpy ./test.py
+
+after_success:
+ - pip install coveralls
+ - coveralls
+
+after_script:
+ - coverage report
+ - pip install pyflakes pep8
+ - pyflakes . | tee >(wc -l)
+ - pep8 --statistics --count .
+
+matrix:
+  fast_finish: true

--- a/test.py
+++ b/test.py
@@ -34,7 +34,6 @@ import pdb
 
 import logging as mod_logging
 import os as mod_os
-import unittest as mod_unittest
 import time as mod_time
 import copy as mod_copy
 import datetime as mod_datetime
@@ -42,6 +41,11 @@ import random as mod_random
 import math as mod_math
 import sys as mod_sys
 import xml.dom.minidom as mod_minidom
+
+try:
+    import unittest2 as mod_unittest
+except ImportError:
+    import unittest as mod_unittest
 
 import gpxpy as mod_gpxpy
 import gpxpy.gpx as mod_gpx


### PR DESCRIPTION
Because `pip install lxml` involves slow building lxml from source, use lxml wheels where available.

Use unittest2 for Python 2.6.

Run tests on Travis CI with coverage, and report coverage to Coveralls. Coverage is a good 85%. This gives reports like [this](https://travis-ci.org/hugovk/gpxpy/builds/116115946) and [this](https://coveralls.io/builds/5421207).

TODO: Ideally before merge, please can you enable these free services:
* [ ] [Travis CI](https://travis-ci.org/profile)
* [ ] [Coveralls](https://coveralls.io/repos/new)
