### PR TITLE
Allow forcing version

### DIFF
--- a/gpxpy/__init__.py
+++ b/gpxpy/__init__.py
@@ -15,7 +15,7 @@
 # limitations under the License.
 
 
-def parse(xml_or_file, parser=None):
+def parse(xml_or_file, parser=None, version = None):
     """
     Parse xml (string) or file object. This is just an wrapper for
     GPXParser.parse() function.
@@ -31,4 +31,4 @@ def parse(xml_or_file, parser=None):
 
     parser = mod_parser.GPXParser(xml_or_file, parser=parser)
 
-    return parser.parse()
+    return parser.parse(version)

--- a/gpxpy/parser.py
+++ b/gpxpy/parser.py
@@ -215,6 +215,7 @@ class GPXParser:
 
         if node is None:
             raise mod_gpx.GPXException('Document must have a `gpx` root node.')
+
         if version is None:
             version = self.xml_parser.get_node_attribute(node, 'version')
 

--- a/gpxpy/parser.py
+++ b/gpxpy/parser.py
@@ -172,7 +172,7 @@ class GPXParser:
         self.xml = mod_utils.make_str(text)
         self.gpx = mod_gpx.GPX()
 
-    def parse(self):
+    def parse(self, version = None):
         """
         Parses the XML file and returns a GPX object.
 
@@ -193,7 +193,7 @@ class GPXParser:
             else:
                 raise mod_gpx.GPXException('Invalid parser type: %s' % self.xml_parser_type)
 
-            self.__parse_dom()
+            self.__parse_dom(version)
 
             return self.gpx
         except Exception as e:
@@ -210,12 +210,12 @@ class GPXParser:
             # it is available with GPXXMLSyntaxException.original_exception:
             raise mod_gpx.GPXXMLSyntaxException('Error parsing XML: %s' % str(e), e)
 
-    def __parse_dom(self):
+    def __parse_dom(self, version = None):
         node = self.xml_parser.get_first_child(name='gpx')
 
         if node is None:
             raise mod_gpx.GPXException('Document must have a `gpx` root node.')
-
-        version = self.xml_parser.get_node_attribute(node, 'version')
+        if version is None:
+            version = self.xml_parser.get_node_attribute(node, 'version')
 
         mod_gpxfield.gpx_fields_from_xml(self.gpx, self.xml_parser, node, version)


### PR DESCRIPTION
Change allows one to force a gpx version to be used. Useful for gpx files which use extensions but don't set the version attribute of the gpx node, or don't set it to "1.1".

The main use of this is to let you call the parse function like so:
gpx = gpxpy.parse(gpx_file, version = "1.1")