### PR TITLE
Add test for Force Version change and test for files with UTF-8 BOM

### DIFF
--- a/test.py
+++ b/test.py
@@ -151,14 +151,14 @@ class AbstractTests:
     def get_parser_type(self):
         raise Exception('Implement this in subclasses')
 
-    def parse(self, file, encoding=None):
+    def parse(self, file, encoding=None, version = None):
         if PYTHON_VERSION[0] == '3':
             f = open('test_files/%s' % file, encoding=encoding)
         else:
             f = open('test_files/%s' % file)
 
         parser = mod_parser.GPXParser(f, parser=self.get_parser_type())
-        gpx = parser.parse()
+        gpx = parser.parse(version)
         f.close()
 
         if not gpx:
@@ -318,6 +318,20 @@ class AbstractTests:
         name = gpx.waypoints[0].name
 
         self.assertTrue(make_str(name) == 'šđčćž')
+
+    def test_unicode_bom(self):
+        gpx = self.parse('unicode3.gpx')
+
+        name = gpx.waypoints[0].name
+
+        self.assertTrue(make_str(name) == 'test')
+
+    def test_force_version(self):
+        gpx = self.parse('unicode3.gpx', version = '1.1')
+
+        security = gpx.waypoints[0].extensions['security']
+
+        self.assertTrue(make_str(security) == 'Open')
 
     def test_nearest_location_1(self):
         gpx = self.parse('korita-zbevnica.gpx')

--- a/test_files/unicode3.gpx
+++ b/test_files/unicode3.gpx
@@ -1,0 +1,19 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<gpx>
+  <wpt lat="43.309634" lon="3.515386">
+    <ele>-14.6</ele>
+    <time>2016-05-27T10:08:47.8Z</time>
+    <geoidheight>0</geoidheight>
+    <name>test</name>
+    <cmt>69.26474016</cmt>
+    <desc>test desc</desc>
+    <fix></fix>
+    <sat>4</sat>
+    <hdop>16.2</hdop>
+    <vdop>9.3</vdop>
+    <pdop>18.7</pdop>
+    <extensions>
+      <security>Open</security>
+    </extensions>
+  </wpt>
+</gpx>


### PR DESCRIPTION
Added tests 'test_unicode_bom' and 'test_force_version'.
The 'unicode3.gpx' file has a UTF-8 byte order marker. This probably won't be displayed in many text editors, but it is there. It also has no attributes in the gpx node, but does have an extensions node.

A potential issue is that the force version test will fail if the parser doesn't handle UTF-8 files with byte order markers. This is because I used the same file for the byte order marker test as well as the force version test.

I'm not too familiar with this testing system. I hope I've done it right. I wrote these because the coverage checker complained about reduced coverage in my UTF-8 BOM support pull request.

p.s. I noticed that there are two 'test_unicode' functions defined - one on line 315, the other on 1616. I don't know if that matters or not, but it didn't seem right.