### PR TITLE
Fix Unicode BOM related behaviour

### DIFF
--- a/gpxpy/parser.py
+++ b/gpxpy/parser.py
@@ -165,8 +165,6 @@ class GPXParser:
 
     def init(self, xml_or_file):
         text = xml_or_file.read() if hasattr(xml_or_file, 'read') else xml_or_file
-        if text[:3] == "\xEF\xBB\xBF": #Remove utf-8 Byte Order Mark (BOM) if present
-            text = text[3:]
         self.xml = mod_utils.make_str(text)
         self.gpx = mod_gpx.GPX()
 

--- a/test.py
+++ b/test.py
@@ -338,7 +338,7 @@ class AbstractTests:
 
         name = gpx.waypoints[0].name
 
-        self.assertTrue(make_str(name) == 'bom noencoding \xc5\x91')
+        self.assertTrue(make_str(name) == 'bom noencoding ő')
 
     def test_force_version(self):
         gpx = self.parse('unicode_with_bom.gpx', version = '1.1', encoding='utf-8')

--- a/test.py
+++ b/test.py
@@ -105,7 +105,7 @@ def custom_open(filename, encoding=None):
     if PYTHON_VERSION[0] == '3':
         return open(filename, encoding=encoding)
     elif encoding == 'utf-8':
-        mod_codecs.open(filename, encoding='utf-7')
+        mod_codecs.open(filename, encoding='utf-8')
     return open(filename)
 
 

--- a/test.py
+++ b/test.py
@@ -333,6 +333,13 @@ class AbstractTests:
 
         self.assertTrue(make_str(name) == 'test')
 
+    def test_unicode_bom_noencoding(self):
+        gpx = self.parse('unicode_with_bom_noencoding.gpx', encoding='utf-8')
+
+        name = gpx.waypoints[0].name
+
+        self.assertTrue(make_str(name) == 'bom noencoding \xc5\x91')
+
     def test_force_version(self):
         gpx = self.parse('unicode_with_bom.gpx', version = '1.1', encoding='utf-8')
 

--- a/test_files/unicode_with_bom_noencoding.gpx
+++ b/test_files/unicode_with_bom_noencoding.gpx
@@ -1,0 +1,8 @@
+﻿<?xml version="1.0"?>
+<gpx version="1.1" creator="GPS Visualizer http://www.gpsvisualizer.com/" xmlns="http://www.topografix.com/GPX/1/1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.topografix.com/GPX/1/1 http://www.topografix.com/GPX/1/1/gpx.xsd">
+<wpt lat="0.1" lon="0.1">
+  <ele>0.0</ele>
+  <name>bom noencoding ő</name>
+  <desc>bom desc</desc>
+</wpt>
+</gpx>


### PR DESCRIPTION
Removed the manual BOM removing code.
Added test and test file with bom but without encoding.
Using utf-8 for custom_open (instead of the weird utf-7 (?))