### PR TITLE
utils.make_str accepts float

### DIFF
--- a/gpxpy/utils.py
+++ b/gpxpy/utils.py
@@ -109,7 +109,9 @@ def hash_object(obj, attributes):
 
 
 def make_str(s):
-    """ Convert a str or unicode object into a str type. """
+    """ Convert a str or unicode or float object into a str type. """
+    if isinstance(s, float):
+        return '{:f}'.format(s)
     if PYTHON_VERSION[0] == '2':
         if isinstance(s, unicode):
             return s.encode("utf-8")


### PR DESCRIPTION
the real bug is that the FLOAT_TYPE converter is not used for latitude and longitude.
And FLOAT_TYPE has the same bug: it can deliver scientific notation which is not
legal GPX 1/1.

Test case: latitude or longitude very near 0 like 0.00004

Fix only works from python 2.6 upwards.