### PR TITLE
lat/long/ele must not have scientific notation

### DIFF
--- a/gpxpy/gpxfield.py
+++ b/gpxpy/gpxfield.py
@@ -64,7 +64,7 @@ def parse_time(string):
 class FloatConverter:
     def __init__(self):
         self.from_string = lambda string : None if string is None else float(string.strip())
-        self.to_string =   lambda flt    : str(flt)
+        self.to_string =   lambda flt    : mod_utils.make_str(flt)
 
 
 class IntConverter:

--- a/gpxpy/utils.py
+++ b/gpxpy/utils.py
@@ -109,7 +109,9 @@ def hash_object(obj, attributes):
 
 
 def make_str(s):
-    """ Convert a str or unicode object into a str type. """
+    """ Convert a str or unicode or float object into a str type. """
+    if isinstance(s, float):
+        return '{:f}'.format(s)
     if PYTHON_VERSION[0] == '2':
         if isinstance(s, unicode):
             return s.encode("utf-8")

--- a/gpxpy/utils.py
+++ b/gpxpy/utils.py
@@ -109,7 +109,13 @@ def hash_object(obj, attributes):
 
 
 def make_str(s):
-    """ Convert a str or unicode object into a str type. """
+    """ Convert a str or unicode or float object into a str type. """
+    if isinstance(s, float):
+        result = str(s)
+        if not 'e' in result:
+            return result
+        # scientific notation is illegal in GPX 1/1
+        return '{:f}'.format(s).rstrip('0').rstrip('.')
     if PYTHON_VERSION[0] == '2':
         if isinstance(s, unicode):
             return s.encode("utf-8")

--- a/gpxpy/utils.py
+++ b/gpxpy/utils.py
@@ -109,9 +109,7 @@ def hash_object(obj, attributes):
 
 
 def make_str(s):
-    """ Convert a str or unicode or float object into a str type. """
-    if isinstance(s, float):
-        return '{:f}'.format(s)
+    """ Convert a str or unicode object into a str type. """
     if PYTHON_VERSION[0] == '2':
         if isinstance(s, unicode):
             return s.encode("utf-8")

--- a/test.py
+++ b/test.py
@@ -2822,6 +2822,16 @@ class AbstractTests:
         self.assertEquals(gpx.tracks[0].segments[0].points[0].time, mod_datetime.datetime(2014, 2, 2, 2, 23, 18))
 
 
+    def test_small_floats(self):
+        """GPX 1/1 does not allow scientific notation but that is what gpxpy writes right now."""
+        f = open('test_files/track-with-small-floats.gpx', 'r')
+
+        parser = mod_parser.GPXParser(f, parser=self.get_parser_type())
+
+        gpx = parser.parse()
+        xml = gpx.to_xml()
+        self.assertNotIn('e-', xml)
+
 class LxmlTests(mod_unittest.TestCase, AbstractTests):
     def get_parser_type(self):
         return 'lxml'

--- a/test_files/track-with-small-floats.gpx
+++ b/test_files/track-with-small-floats.gpx
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Track with small values for floats: scientific notation is illegal -->
+<gpx
+  version="1.0"
+  creator="GPSBabel - http://www.gpsbabel.org"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xmlns="http://www.topografix.com/GPX/1/0"
+  xsi:schemaLocation="http://www.topografix.com/GPX/1/0 http://www.topografix.com/GPX/1/0/gpx.xsd">
+<time>2011-07-05T04:11:41Z</time>
+<bounds minlat="45.479033517" minlon="13.507589780" maxlat="45.485465008" maxlon="13.520498463"/>
+<trk>
+  <name>Untitled Path</name>
+<trkseg>
+<trkpt lat="0.000091697" lon="0.007589780">
+  <ele>10.000000</ele>
+</trkpt>
+<trkpt lat="0.084886217" lon="0.000081658">
+  <ele>12.000000</ele>
+</trkpt>
+<trkpt lat="0.084886217" lon="0.000081658">
+  <ele>0.000005</ele>
+</trkpt>
+</trkseg>
+</trk>
+</gpx>

--- a/test_files/track-with-small-floats.gpx
+++ b/test_files/track-with-small-floats.gpx
@@ -1,13 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- Track with small values for floats: scientific notation is illegal -->
 <gpx
-  version="1.0"
-  creator="GPSBabel - http://www.gpsbabel.org"
+  version="1.1"
   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-  xmlns="http://www.topografix.com/GPX/1/0"
-  xsi:schemaLocation="http://www.topografix.com/GPX/1/0 http://www.topografix.com/GPX/1/0/gpx.xsd">
-<time>2011-07-05T04:11:41Z</time>
-<bounds minlat="45.479033517" minlon="13.507589780" maxlat="45.485465008" maxlon="13.520498463"/>
+  creator="Wolfgang Rohdewald"
+  xmlns="http://www.topografix.com/GPX/1/1"
+  xsi:schemaLocation="http://www.topografix.com/GPX/1/1 http://www.topografix.com/GPX/1/1/gpx.xsd">
 <trk>
   <name>Untitled Path</name>
 <trkseg>


### PR DESCRIPTION
because that breaks the definition of GPX 1/1

there is a wordpress plugin "Trackviewer" which does not accept badly formed gpx files for upload, including those with scientific notation