### PR TITLE
Used named logger

### DIFF
--- a/gpxpy/geo.py
+++ b/gpxpy/geo.py
@@ -19,6 +19,8 @@ import math as mod_math
 
 from . import utils as mod_utils
 
+log = mod_logging.getLogger(__name__)
+
 # Generic geo related function and class(es)
 
 # One degree in meters:
@@ -101,7 +103,7 @@ def calculate_max_speed(speeds_and_distances):
     size = float(len(speeds_and_distances))
 
     if size < 20:
-        mod_logging.debug('Segment too small to compute speed, size=%s', size)
+        log.debug('Segment too small to compute speed, size=%s', size)
         return None
 
     distances = list(map(lambda x: x[1], speeds_and_distances))

--- a/gpxpy/gpx.py
+++ b/gpxpy/gpx.py
@@ -28,6 +28,8 @@ from . import utils as mod_utils
 from . import geo as mod_geo
 from . import gpxfield as mod_gpxfield
 
+log = mod_logging.getLogger(__name__)
+
 # GPX date format to be used when writing the GPX output:
 DATE_FORMAT = '%Y-%m-%dT%H:%M:%SZ'
 
@@ -915,8 +917,8 @@ class GPXTrackSegment:
         if 0 < point_no < len(self.points) - 1:
             next_point = self.points[point_no + 1]
 
-        #mod_logging.debug('previous: %s' % previous_point)
-        #mod_logging.debug('next: %s' % next_point)
+        #log.debug('previous: %s' % previous_point)
+        #log.debug('next: %s' % next_point)
 
         speed_1 = point.speed_between(previous_point)
         speed_2 = point.speed_between(next_point)
@@ -943,7 +945,7 @@ class GPXTrackSegment:
         delta : float
             Elevation delta in meters to apply to track
         """
-        mod_logging.debug('delta = %s' % delta)
+        log.debug('delta = %s' % delta)
 
         if not delta:
             return
@@ -1036,11 +1038,11 @@ class GPXTrackSegment:
             last = self.points[-2]
 
         if not last.time or not first.time:
-            mod_logging.debug('Can\'t find time')
+            log.debug('Can\'t find time')
             return None
 
         if last.time < first.time:
-            mod_logging.debug('Not enough time data')
+            log.debug('Not enough time data')
             return None
 
         return mod_utils.total_seconds(last.time - first.time)
@@ -1108,11 +1110,11 @@ class GPXTrackSegment:
         last_time = self.points[-1].time
 
         if not first_time and not last_time:
-            mod_logging.debug('No times for track segment')
+            log.debug('No times for track segment')
             return None
 
         if not first_time <= time <= last_time:
-            mod_logging.debug('Not in track (search for:%s, start:%s, end:%s)' % (time, first_time, last_time))
+            log.debug('Not in track (search for:%s, start:%s, end:%s)' % (time, first_time, last_time))
             return None
 
         for point in self.points:
@@ -1990,7 +1992,7 @@ class GPX:
             track.reduce_points(min_distance)
 
         # TODO
-        mod_logging.debug('Track reduced to %s points' % self.get_track_points_no())
+        log.debug('Track reduced to %s points' % self.get_track_points_no())
 
     def adjust_time(self, delta):
         """

--- a/gpxpy/parser.py
+++ b/gpxpy/parser.py
@@ -29,6 +29,7 @@ from . import gpx as mod_gpx
 from . import utils as mod_utils
 from . import gpxfield as mod_gpxfield
 
+log = mod_logging.getLogger(__name__)
 
 class XMLParser:
     """
@@ -199,8 +200,8 @@ class GPXParser:
             return self.gpx
         except Exception as e:
             # The exception here can be a lxml or minidom exception.
-            mod_logging.debug('Error in:\n%s\n-----------\n' % self.xml)
-            mod_logging.exception(e)
+            log.debug('Error in:\n%s\n-----------\n' % self.xml)
+            log.exception(e)
 
             # The library should work in the same way regardless of the
             # underlying XML parser that's why the exception thrown


### PR DESCRIPTION
Use a named loggers in all modules of gpxpy (`log = mod_logging.getLogger(__name__)`) -- as recommended by https://docs.python.org/3/library/logging.html
This enables applications to configure gpxpy's logger separately (e.g. `logging.getLogger('gpxpy').setLevel(logging.CRITICAL)`...).

