### PR TITLE
Enhancement/gpx adjust time

### DIFF
--- a/gpxpy/gpx.py
+++ b/gpxpy/gpx.py
@@ -2051,7 +2051,7 @@ class GPX:
             Positive time delta will adjust times into the future
             Negative time delta will adjust times into the past
         all : bool
-            Adjust time for waypoints and routes also.
+            When true, also adjusts time for waypoints and routes.
         """
         if self.time:
             self.time += delta
@@ -2073,7 +2073,7 @@ class GPX:
         Parameters
         ----------
         all : bool
-            Remove time for waypoints and routes also.
+            When true, also removes time data for waypoints and routes.
         """
         for track in self.tracks:
             track.remove_time()


### PR DESCRIPTION
As discussed in issue https://github.com/tkrajina/gpxpy/issues/93.

Added optional flag to also adjust time of waypoints and routes when using the method `GPX.adjust_time()`.

To improve consistency, the same flag was also added to the `GPX.remove_time()` method.