### PR TITLE
Drop support for EOL Python

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,9 +5,7 @@ sudo: false
 
 # Those without lxml wheels first because building lxml is slow
 python:
- - 3.2
  - 2.7
- - 3.3
  - 3.4
  - 3.5
  - 3.6
@@ -19,22 +17,9 @@ env:
 
 install:
 # Check whether to install lxml
-# Pin version 3.2 to lxml 3.6 (end of support)
- - if [ "$XMLPARSER" == "LXML" ]; then
-     case "$TRAVIS_PYTHON_VERSION" in
-       "2.7"|"3.3"|"3.4"|"3.5"|"3.6")
-         pip install lxml
-         ;;
-       "3.2")
-         pip install lxml==3.6
-         ;;
-     esac
-   fi
+ - if [ "$XMLPARSER" == "LXML" ]; then pip install lxml; fi
 
-
- # Coveralls 4.0 doesn't support Python 3.2
- - if [ "$TRAVIS_PYTHON_VERSION" == "3.2" ]; then travis_retry pip install coverage==3.7.1; fi
- - if [ "$TRAVIS_PYTHON_VERSION" != "3.2" ]; then travis_retry pip install coverage; fi
+ - travis_retry pip install coverage
 
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ env:
 
 install:
 # Check whether to install lxml
-# Pin versions 2.6 and 3.2 to lxml 3.6 (end of support)
+# Pin version 3.2 to lxml 3.6 (end of support)
  - if [ "$XMLPARSER" == "LXML" ]; then
      case "$TRAVIS_PYTHON_VERSION" in
        "2.7"|"3.3"|"3.4"|"3.5"|"3.6")
@@ -35,8 +35,6 @@ install:
  # Coveralls 4.0 doesn't support Python 3.2
  - if [ "$TRAVIS_PYTHON_VERSION" == "3.2" ]; then travis_retry pip install coverage==3.7.1; fi
  - if [ "$TRAVIS_PYTHON_VERSION" != "3.2" ]; then travis_retry pip install coverage; fi
-
- - if [ "$TRAVIS_PYTHON_VERSION" == "2.6" ]; then pip install unittest2; fi
 
 
 script:

--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ The GPX version is automatically determined when parsing by reading the version 
 
 ## Pull requests
 
-OK, so you found a bug and fixed it. Before sending a pull request -- check that all tests are OK with Python 2.6+ and Python 3+.
+OK, so you found a bug and fixed it. Before sending a pull request -- check that all tests are OK with Python 2.7 and Python 3.2+.
 
 Run all tests with:
 

--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ The GPX version is automatically determined when parsing by reading the version 
 
 ## Pull requests
 
-OK, so you found a bug and fixed it. Before sending a pull request -- check that all tests are OK with Python 2.7 and Python 3.2+.
+OK, so you found a bug and fixed it. Before sending a pull request -- check that all tests are OK with Python 2.7 and Python 3.4+.
 
 Run all tests with:
 

--- a/test.py
+++ b/test.py
@@ -36,6 +36,7 @@ import datetime as mod_datetime
 import random as mod_random
 import math as mod_math
 import sys as mod_sys
+import unittest as mod_unittest
 import xml.dom.minidom as mod_minidom
 
 try:
@@ -45,11 +46,6 @@ except:
         import xml.etree.cElementTree as mod_etree
     except:
         import xml.etree.ElementTree as mod_etree
-
-try:
-    import unittest2 as mod_unittest
-except ImportError:
-    import unittest as mod_unittest
 
 import gpxpy as mod_gpxpy
 import gpxpy.gpx as mod_gpx


### PR DESCRIPTION
Python 2.6 and 3.2-3.3 are EOL and no longer receiving security updates (or any updates) from the core Python team.

They're also little used.

Here's the pip installs for gpxpy from PyPI for July 2018:

| python_version | percent | download_count |
| -------------- | ------: | -------------: |
| 2.7            |  82.58% |          3,561 |
| 3.6            |  12.73% |            549 |
| 3.5            |   3.43% |            148 |
| 3.7            |   1.00% |             43 |
| 3.4            |   0.26% |             11 |
| Total          |         |          4,312 |

Source: `pypinfo --start-date 2018-07-01 --end-date 2018-07-31 --percent --markdown gpxpy pyversion`

Python 2.6 has already been dropped (#105), this removes some extra code for that.

It also removes 3.2 and 3.3 support which simplifies the Travis CI config, and also means CI builds are quicker (12m -> 6m total time). 

The main benefit is being able to make full use of modern Python features in the future without worrying about supporting EOL Python.