### PR TITLE
Option to override xsi:schemaLocation for custom extensions schema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v1.3.4
+
+* Added custom schemaLocation support
+
 ## v1.3.3
 
 * Added avg time to gpxpnfo

--- a/gpxpy/gpx.py
+++ b/gpxpy/gpx.py
@@ -1966,7 +1966,8 @@ class GPX:
                  'bounds', 'waypoints', 'routes', 'tracks', 'author_link',
                  'author_link_text', 'author_link_type', 'copyright_author',
                  'copyright_year', 'copyright_license', 'link_type',
-                 'metadata_extensions', 'extensions', 'nsmap')
+                 'metadata_extensions', 'extensions', 'nsmap',
+                 'schema_locations')
 
     def __init__(self):
         self.version = None
@@ -1993,6 +1994,7 @@ class GPX:
         self.routes = []
         self.tracks = []
         self.nsmap = {}
+        self.schema_locations = None
 
     def simplify(self, max_distance=None):
         """
@@ -2701,12 +2703,21 @@ class GPX:
             self.creator = 'gpx.py -- https://github.com/tkrajina/gpxpy'
 
         self.nsmap['xsi'] = 'http://www.w3.org/2001/XMLSchema-instance'
-        self.nsmap['defaultns'] = 'http://www.topografix.com/GPX/{0}'.format(version.replace('.', '/'))
-        schemalocs = 'http://www.topografix.com/GPX/{0} http://www.topografix.com/GPX/{0}/gpx.xsd'
-        xml_attributes = {'xsi:schemaLocation':
-                          schemalocs.format(version.replace('.', '/'))}
+        self.nsmap['defaultns'] = 'http://www.topografix.com/GPX/{0}'.format(
+            version.replace('.', '/')
+        )
 
-        content = mod_gpxfield.gpx_fields_to_xml(self, 'gpx', version, custom_attributes=xml_attributes, nsmap=self.nsmap, prettyprint=prettyprint)
+        if not self.schema_locations:
+            self.schema_locations = (
+                'http://www.topografix.com/GPX/{0} '
+                'http://www.topografix.com/GPX/{0}/gpx.xsd'
+            ).format(version.replace('.', '/'))
+
+        content = mod_gpxfield.gpx_fields_to_xml(
+            self, 'gpx', version,
+            custom_attributes={'xsi:schemaLocation': self.schema_locations},
+            nsmap=self.nsmap, prettyprint=prettyprint
+        )
 
         return '<?xml version="1.0" encoding="UTF-8"?>\n' + content.strip()
 

--- a/gpxpy/gpx.py
+++ b/gpxpy/gpx.py
@@ -1994,7 +1994,7 @@ class GPX:
         self.routes = []
         self.tracks = []
         self.nsmap = {}
-        self.schema_locations = None
+        self.schema_locations = []
 
     def simplify(self, max_distance=None):
         """
@@ -2708,15 +2708,19 @@ class GPX:
         )
 
         if not self.schema_locations:
-            self.schema_locations = (
-                'http://www.topografix.com/GPX/{0} '
-                'http://www.topografix.com/GPX/{0}/gpx.xsd'
-            ).format(version.replace('.', '/'))
+            ver = version.replace('.', '/')
+            self.schema_locations = [
+                'http://www.topografix.com/GPX/{0}'.format(ver),
+                'http://www.topografix.com/GPX/{0}/gpx.xsd'.format(ver),
+            ]
 
         content = mod_gpxfield.gpx_fields_to_xml(
             self, 'gpx', version,
-            custom_attributes={'xsi:schemaLocation': self.schema_locations},
-            nsmap=self.nsmap, prettyprint=prettyprint
+            custom_attributes={
+                'xsi:schemaLocation': ' '.join(self.schema_locations)
+            },
+            nsmap=self.nsmap,
+            prettyprint=prettyprint
         )
 
         return '<?xml version="1.0" encoding="UTF-8"?>\n' + content.strip()

--- a/gpxpy/gpx.py
+++ b/gpxpy/gpx.py
@@ -2703,15 +2703,19 @@ class GPX:
             self.creator = 'gpx.py -- https://github.com/tkrajina/gpxpy'
 
         self.nsmap['xsi'] = 'http://www.w3.org/2001/XMLSchema-instance'
+
+        version_path = version.replace('.', '/')
+
         self.nsmap['defaultns'] = 'http://www.topografix.com/GPX/{0}'.format(
-            version.replace('.', '/')
+            version_path
         )
 
         if not self.schema_locations:
-            ver = version.replace('.', '/')
             self.schema_locations = [
-                'http://www.topografix.com/GPX/{0}'.format(ver),
-                'http://www.topografix.com/GPX/{0}/gpx.xsd'.format(ver),
+                p.format(version_path) for p in (
+                    'http://www.topografix.com/GPX/{0}',
+                    'http://www.topografix.com/GPX/{0}/gpx.xsd',
+                )
             ]
 
         content = mod_gpxfield.gpx_fields_to_xml(

--- a/gpxpy/gpxfield.py
+++ b/gpxpy/gpxfield.py
@@ -451,9 +451,12 @@ def gpx_fields_to_xml(instance, tag, version, custom_attributes=None,
         body.append('\n' + indent + '<' + tag)
         if tag == 'gpx':  # write nsmap in root node
             body.append(' xmlns="{0}"'.format(nsmap['defaultns']))
-            for prefix, URI in nsmap.items():
-                if prefix != 'defaultns':
-                    body.append(' xmlns:{0}="{1}"'.format(prefix, URI))
+            namespaces = set(nsmap.keys())
+            namespaces.remove('defaultns')
+            for prefix in sorted(namespaces):
+                body.append(
+                    ' xmlns:{0}="{1}"'.format(prefix, nsmap[prefix])
+                )
         if custom_attributes:
             # Make sure to_xml() always return attributes in the same order:
             for key in sorted(custom_attributes.keys()):

--- a/gpxpy/parser.py
+++ b/gpxpy/parser.py
@@ -16,6 +16,7 @@
 
 import logging as mod_logging
 import re as mod_re
+
 try:
     import lxml.etree as mod_etree  # Load LXML or fallback to cET or ET
 except ImportError:
@@ -25,8 +26,8 @@ except ImportError:
         import xml.etree.ElementTree as mod_etree
 
 from . import gpx as mod_gpx
-from . import gpxfield as mod_gpxfield
 from . import utils as mod_utils
+from . import gpxfield as mod_gpxfield
 
 log = mod_logging.getLogger(__name__)
 

--- a/gpxpy/parser.py
+++ b/gpxpy/parser.py
@@ -17,6 +17,11 @@
 import logging as mod_logging
 import re as mod_re
 
+from . import gpx as mod_gpx
+from . import gpxfield as mod_gpxfield
+from . import utils as mod_utils
+
+
 try:
     import lxml.etree as mod_etree  # Load LXML or fallback to cET or ET
 except ImportError:
@@ -25,9 +30,6 @@ except ImportError:
     except ImportError:
         import xml.etree.ElementTree as mod_etree
 
-from . import gpx as mod_gpx
-from . import utils as mod_utils
-from . import gpxfield as mod_gpxfield
 
 log = mod_logging.getLogger(__name__)
 
@@ -99,6 +101,11 @@ class GPXParser:
                 else:
                     mod_etree.register_namespace(prefix, URI.strip('"'))
             self.gpx.nsmap[prefix] = URI.strip('"')
+
+        schema_loc = mod_re.search(r'\sxsi:schemaLocation="[^"]+"', self.xml)
+        if schema_loc:
+            _, _, value = schema_loc.group(0).partition('=')
+            self.gpx.schema_locations = value.strip('"')
 
         # Remove default namespace to simplify processing later
         # TODO: change regex to accept ' also

--- a/gpxpy/parser.py
+++ b/gpxpy/parser.py
@@ -102,7 +102,7 @@ class GPXParser:
         schema_loc = mod_re.search(r'\sxsi:schemaLocation="[^"]+"', self.xml)
         if schema_loc:
             _, _, value = schema_loc.group(0).partition('=')
-            self.gpx.schema_locations = value.strip('"').split(' ')
+            self.gpx.schema_locations = value.strip('"').split()
 
         # Remove default namespace to simplify processing later
         # TODO: change regex to accept ' also

--- a/gpxpy/parser.py
+++ b/gpxpy/parser.py
@@ -16,12 +16,6 @@
 
 import logging as mod_logging
 import re as mod_re
-
-from . import gpx as mod_gpx
-from . import gpxfield as mod_gpxfield
-from . import utils as mod_utils
-
-
 try:
     import lxml.etree as mod_etree  # Load LXML or fallback to cET or ET
 except ImportError:
@@ -30,6 +24,9 @@ except ImportError:
     except ImportError:
         import xml.etree.ElementTree as mod_etree
 
+from . import gpx as mod_gpx
+from . import gpxfield as mod_gpxfield
+from . import utils as mod_utils
 
 log = mod_logging.getLogger(__name__)
 

--- a/gpxpy/parser.py
+++ b/gpxpy/parser.py
@@ -102,7 +102,7 @@ class GPXParser:
         schema_loc = mod_re.search(r'\sxsi:schemaLocation="[^"]+"', self.xml)
         if schema_loc:
             _, _, value = schema_loc.group(0).partition('=')
-            self.gpx.schema_locations = value.strip('"')
+            self.gpx.schema_locations = value.strip('"').split(' ')
 
         # Remove default namespace to simplify processing later
         # TODO: change regex to accept ' also

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ import distutils.core as mod_distutilscore
 
 mod_distutilscore.setup(
     name='gpxpy',
-    version='1.3.3',
+    version='1.3.4',
     description='GPX file parser and GPS track manipulation library',
     license='Apache License, Version 2.0',
     author='Tomo Krajina',

--- a/test.py
+++ b/test.py
@@ -3250,24 +3250,24 @@ class GPXTests(mod_unittest.TestCase):
         gpx.nsmap = {
             'gpxx': 'http://www.garmin.com/xmlschemas/GpxExtensions/v3',
         }
-        gpx.schema_locations = (
-           'http://www.topografix.com/GPX/1/1 '
-           'http://www.topografix.com/GPX/1/1/gpx.xsd '
-           'http://www.garmin.com/xmlschemas/GpxExtensions/v3 '
-           'http://www.garmin.com/xmlschemas/GpxExtensionsv3.xsd'
-        )
+        gpx.schema_locations = [
+           'http://www.topografix.com/GPX/1/1',
+           'http://www.topografix.com/GPX/1/1/gpx.xsd',
+           'http://www.garmin.com/xmlschemas/GpxExtensions/v3',
+           'http://www.garmin.com/xmlschemas/GpxExtensionsv3.xsd',
+        ]
         with custom_open('test_files/custom_schema_locations.gpx') as f:
             self.assertEquals(gpx.to_xml(), f.read())
 
     def test_parse_custom_schema_locations(self):
         gpx = self.parse('custom_schema_locations.gpx')
         self.assertEquals(
-            (
-                'http://www.topografix.com/GPX/1/1 '
-                'http://www.topografix.com/GPX/1/1/gpx.xsd '
-                'http://www.garmin.com/xmlschemas/GpxExtensions/v3 '
-                'http://www.garmin.com/xmlschemas/GpxExtensionsv3.xsd'
-            ),
+            [
+                'http://www.topografix.com/GPX/1/1',
+                'http://www.topografix.com/GPX/1/1/gpx.xsd',
+                'http://www.garmin.com/xmlschemas/GpxExtensions/v3',
+                'http://www.garmin.com/xmlschemas/GpxExtensionsv3.xsd',
+            ],
             gpx.schema_locations
         )
 

--- a/test.py
+++ b/test.py
@@ -175,7 +175,7 @@ class GPXTests(mod_unittest.TestCase):
     Add tests here.
     """
 
-    def parse(self, file, encoding=None, version = None):
+    def parse(self, file, encoding=None, version=None):
         f = custom_open('test_files/%s' % file, encoding=encoding)
 
         parser = mod_parser.GPXParser(f)
@@ -3239,6 +3239,37 @@ class GPXTests(mod_unittest.TestCase):
 
         with self.assertRaises(mod_gpx.GPXException):
             gpx.fill_time_data_with_regular_intervals(start_time=start_time, end_time=end_time, force=False)
+
+    def test_default_schema_locations(self):
+        gpx = mod_gpx.GPX()
+        with custom_open('test_files/default_schema_locations.gpx') as f:
+            self.assertEquals(gpx.to_xml(), f.read())
+
+    def test_custom_schema_locations(self):
+        gpx = mod_gpx.GPX()
+        gpx.nsmap = {
+            'gpxx': 'http://www.garmin.com/xmlschemas/GpxExtensions/v3',
+        }
+        gpx.schema_locations = (
+           'http://www.topografix.com/GPX/1/1 '
+           'http://www.topografix.com/GPX/1/1/gpx.xsd '
+           'http://www.garmin.com/xmlschemas/GpxExtensions/v3 '
+           'http://www.garmin.com/xmlschemas/GpxExtensionsv3.xsd'
+        )
+        with custom_open('test_files/custom_schema_locations.gpx') as f:
+            self.assertEquals(gpx.to_xml(), f.read())
+
+    def test_parse_custom_schema_locations(self):
+        gpx = self.parse('custom_schema_locations.gpx')
+        self.assertEquals(
+            (
+                'http://www.topografix.com/GPX/1/1 '
+                'http://www.topografix.com/GPX/1/1/gpx.xsd '
+                'http://www.garmin.com/xmlschemas/GpxExtensions/v3 '
+                'http://www.garmin.com/xmlschemas/GpxExtensionsv3.xsd'
+            ),
+            gpx.schema_locations
+        )
 
 
 class LxmlTest(mod_unittest.TestCase):

--- a/test_files/custom_schema_locations.gpx
+++ b/test_files/custom_schema_locations.gpx
@@ -1,0 +1,3 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<gpx xmlns="http://www.topografix.com/GPX/1/1" xmlns:gpxx="http://www.garmin.com/xmlschemas/GpxExtensions/v3" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.topografix.com/GPX/1/1 http://www.topografix.com/GPX/1/1/gpx.xsd http://www.garmin.com/xmlschemas/GpxExtensions/v3 http://www.garmin.com/xmlschemas/GpxExtensionsv3.xsd" version="1.1" creator="gpx.py -- https://github.com/tkrajina/gpxpy">
+</gpx>

--- a/test_files/default_schema_locations.gpx
+++ b/test_files/default_schema_locations.gpx
@@ -1,0 +1,3 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<gpx xmlns="http://www.topografix.com/GPX/1/1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.topografix.com/GPX/1/1 http://www.topografix.com/GPX/1/1/gpx.xsd" version="1.1" creator="gpx.py -- https://github.com/tkrajina/gpxpy">
+</gpx>


### PR DESCRIPTION
Added the ability to set schemaLocation explicitly in a GPX object. This is done to support custom schemas for extensions when generating xml (for example, http://developer.garmin.com/downloads/connect-api/sample_file.gpx)

```
gpx = gpxpy.GPX()
gpx.schema_locations = [
    'http://www.topografix.com/GPX/1/1',
    'http://www.topografix.com/GPX/1/1/gpx.xsd',
    'http://www.garmin.com/xmlschemas/GpxExtensions/v3',
    'http://www.garmin.com/xmlschemas/GpxExtensionsv3.xsd',
]
```