### PR TITLE
Setup.py: update classifiers, add python_requires and long_description

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -17,10 +17,15 @@
 from setuptools import setup
 
 
+with open('README.md') as f:
+    long_description = f.read()
+
 setup(
     name='gpxpy',
     version='1.3.3',
     description='GPX file parser and GPS track manipulation library',
+    long_description=long_description,
+    long_description_content_type="text/markdown",
     license='Apache License, Version 2.0',
     author='Tomo Krajina',
     author_email='tkrajina@gmail.com',

--- a/setup.py
+++ b/setup.py
@@ -26,6 +26,7 @@ setup(
     author_email='tkrajina@gmail.com',
     url='http://www.trackprofiler.com/gpxpy/index.html',
     packages=['gpxpy', ],
+    python_requires=">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*",
     classifiers=[
         "Programming Language :: Python",
         "Programming Language :: Python :: 2",

--- a/setup.py
+++ b/setup.py
@@ -14,9 +14,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import distutils.core as mod_distutilscore
+from setuptools import setup
 
-mod_distutilscore.setup(
+
+setup(
     name='gpxpy',
     version='1.3.3',
     description='GPX file parser and GPS track manipulation library',

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,11 @@ mod_distutilscore.setup(
     classifiers=[
         "Programming Language :: Python",
         "Programming Language :: Python :: 2",
+        "Programming Language :: Python :: 2.7",
         "Programming Language :: Python :: 3",
+        "Programming Language :: Python :: 3.4",
+        "Programming Language :: Python :: 3.5",
+        "Programming Language :: Python :: 3.6",
     ],
     scripts=['gpxinfo']
 )


### PR DESCRIPTION
Some handy updates to setup.py:

* Update Trove classifiers so the supported versions are clear on PyPI https://pypi.org/project/gpxpy/
* Use `setuptools` rather than `distutils` for:
  * Add `python_requires`, so pip knows which version of this package to install for people's installed Python version
  * Add the README.md contents as `long_description` so https://pypi.org/project/gpxpy/ will show the README instead of "The author of this package has not provided a project description"

For these, make sure you have `pip install -U setuptools twine` and use `twine` for upload.

See:
* https://dustingram.com/articles/2018/03/16/markdown-descriptions-on-pypi
* https://github.com/di/markdown-description-example
