### PR TITLE
Add Python 3.7 classifier and test on CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,12 @@ python:
  - 3.4
  - 3.5
  - 3.6
+# Enable 3.7 without globally enabling sudo and dist: xenial for other build jobs
+matrix:
+  include:
+    - python: 3.7
+      dist: xenial
+      sudo: true
 
 env:
 - XMLPARSER=LXML

--- a/setup.py
+++ b/setup.py
@@ -40,6 +40,7 @@ setup(
         "Programming Language :: Python :: 3.4",
         "Programming Language :: Python :: 3.5",
         "Programming Language :: Python :: 3.6",
+        "Programming Language :: Python :: 3.7",
     ],
     scripts=['gpxinfo']
 )


### PR DESCRIPTION
A little workaround is needed for 3.7 on Travis, see https://github.com/travis-ci/travis-ci/issues/9815.