### PR TITLE
Course computation

### DIFF
--- a/gpxpy/geo.py
+++ b/gpxpy/geo.py
@@ -50,6 +50,48 @@ def haversine_distance(latitude_1: float, longitude_1: float, latitude_2: float,
     return d
 
 
+def get_course(latitude_1: float, longitude_1: float, latitude_2: float, longitude_2: float,
+               loxodromic: bool=True) -> float:
+    """
+    The initial course from one point to another,
+    expressed in decimal degrees clockwise from true North
+    (not magnetic)
+    (0.0 <= value < 360.0)
+
+    Use the default loxodromic model in most cases
+    (except when visualizing the long routes of maritime transport and aeroplanes)
+
+    Implemented from http://www.movable-type.co.uk/scripts/latlong.html
+    (sections 'Bearing' and 'Rhumb lines')
+    """
+
+    d_lon = mod_math.radians(longitude_2 - longitude_1)
+    lat1 = mod_math.radians(latitude_1)
+    lat2 = mod_math.radians(latitude_2)
+
+    if not loxodromic:
+        y = mod_math.sin(d_lon) * mod_math.cos(lat2)
+        x = mod_math.cos(lat1) * mod_math.sin(lat2) - \
+            mod_math.sin(lat1) * mod_math.cos(lat2) * mod_math.cos(d_lon)
+    else:
+        radian_circle = 2*mod_math.pi
+
+        if abs(d_lon) > mod_math.pi:
+            if d_lon > 0:
+                d_lon = - (radian_circle - d_lon)
+            else:
+                d_lon = radian_circle + d_lon
+
+        y = d_lon
+
+        delta = mod_math.pi/4
+        x = mod_math.log(mod_math.tan(delta + 0.5*lat2)
+                         / mod_math.tan(delta + 0.5*lat1))
+
+    course = mod_math.degrees(mod_math.atan2(y, x))
+    return (course + 360.) % 360.
+
+
 def length(locations: List["Location"]=[], _3d: bool=False) -> float:
     if not locations:
         return 0

--- a/gpxpy/gpx.py
+++ b/gpxpy/gpx.py
@@ -21,7 +21,6 @@ import math as mod_math
 import collections as mod_collections
 import copy as mod_copy
 import datetime as mod_datetime
-import datetime as mod_datetime
 
 from . import utils as mod_utils
 from . import geo as mod_geo
@@ -628,9 +627,56 @@ class GPXTrackPoint(mod_geo.Location):
 
         return length / float(seconds)
 
+    def course_between(self, track_point: "GPXTrackPoint", loxodromic: bool=True) -> Optional[float]:
+        """
+        Compute the instantaneous course from one point to another.
+
+        Both loxodromic (Rhumb line) and orthodromic (Great circle) navigation
+        models are available.
+
+        The default navigation model is loxodromic.
+
+        There is no difference between these models in course computation
+        when points are relatively close to each other (less than ≈150 km)
+
+        In most cases the default model is OK.
+
+        However, the orthodromic navigation model can be important for the
+        long-distance (> ≈1000 km) logs acquired from maritime transport
+        or aeroplanes
+
+        Generally, the choice between these two models depends on a vehicle type,
+        distance and navigation equipment used.
+
+        More information on these two navigation models:
+        https://www.movable-type.co.uk/scripts/latlong.html
+
+        NOTE: This is a computed course, not the GPXTrackPoint course that comes in
+              the GPX file.
+
+        Parameters
+        ----------
+        track_point : GPXTrackPoint
+        loxodromic : True
+                     Set to False to use the orthodromic navigation model
+
+        Returns
+        ----------
+        course : float
+                Course returned in decimal degrees, true (not magnetic)
+                (0.0 <= value < 360.0)
+        """
+
+        if not track_point:
+            return None
+
+        course = mod_geo.get_course(self.latitude, self.longitude,
+                                    track_point.latitude, track_point.longitude,
+                                    loxodromic)
+        return course
+
     def __str__(self) -> str:
         return f'[trkpt:{self.latitude},{self.longitude}@{self.elevation}@{self.time}]'
-
 
 class GPXTrackSegment:
     gpx_10_fields = [


### PR DESCRIPTION
This pull request implements the course computation between two points and closes #155.

As @christianhauff mentioned in #155, the course attribute was removed in GPX v1.1

This parameter is extremely useful when we need to visualize vehicle movement on a map (e.g. when we replay the movement logs in vehicle tracking systems).

A vehicle icon on map typically has two dimensions, so to rotate it correctly in each point we need to know its course/heading/bearing/azimuth* to a next point.
_*In most cases for the land-based vehicles these definitions are typically identical_

![image](https://user-images.githubusercontent.com/2414375/71940647-16905780-31c8-11ea-9447-7899d4cfd166.png)
_Original version by WolfgangW; modified and converted to SVG by ctree. [CC BY-SA (https://creativecommons.org/licenses/by-sa/4.0)]_

To compute instantaneous course between two points, a user can choose between **loxodromic** (rhumb line) and **orthodromic** (great-circle) navigation models.

By default the loxodromic navigation model is used in this pull request.
 
Generally, the choice between these two models depends on a vehicle type, distance and navigation equipment used.
      
For most of the GPX logs acquired from land vehicles (cars, cyclists, pedestrians) there is no difference in the course computation models as the route points are relatively close to each other (less than ≈150 km)

The difference, however, is crucial when we have to visualize the long (more than ≈1500 km) routes of sea vehicles and aeroplanes. In this case orthodromic course computation is usually used. 
(when the number of geopoints is low, we can always restore the missing route arc parts).

--
[Essential course computation info](https://www.movable-type.co.uk/scripts/latlong.html)

[GPX v1.0 Developer's Manual: ](https://www.topografix.com/gpx_manual.asp)
```
<course>
Optional in: <wpt> <rtept> <trkpt>

Units: degrees, true

<course>45.2</course>

Instantaneous course at the point.
```

[GPX v.1.1 Schema specification:](https://www.topografix.com/GPX/1/1/#type_degreesType)

```
degreesType
Content	
Base XSD Type: decimal
0.0 <= value < 360.0
Documentation	Used for bearing, heading, course. Units are decimal degrees, true (not magnetic).
```