### PR TITLE
add package __version__ (fixes #116)

### DIFF
--- a/gpxpy/__init__.py
+++ b/gpxpy/__init__.py
@@ -15,6 +15,8 @@
 # limitations under the License.
 
 
+__version__ = '1.3.4'
+
 def parse(xml_or_file, version = None):
     """
     Parse xml (string) or file object. This is just an wrapper for

--- a/setup.py
+++ b/setup.py
@@ -16,13 +16,14 @@
 
 from setuptools import setup
 
+import gpxpy
 
 with open('README.md') as f:
     long_description = f.read()
 
 setup(
     name='gpxpy',
-    version='1.3.4',
+    version=gpxpy.__version__,
     description='GPX file parser and GPS track manipulation library',
     long_description=long_description,
     long_description_content_type="text/markdown",


### PR DESCRIPTION
This change adds `gpxpy.__version__` into the package by moving the version string into `__init__.py` and then importing/reading that value from setup.py.

Tests ran cleanly and coverage remained unchanged.

```
Ran 124 tests in 4.021s

OK (skipped=1)
$
$ coverage report
Name                Stmts   Miss  Cover
---------------------------------------
gpxpy/__init__.py       5      0   100%
gpxpy/geo.py          203     21    90%
gpxpy/gpx.py         1219    184    85%
gpxpy/gpxfield.py     336     35    90%
gpxpy/gpxxml.py        49     16    67%
gpxpy/parser.py        54      7    87%
gpxpy/utils.py         55     21    62%
---------------------------------------
TOTAL                1921    284    85%
```
This addresses enhancement/issue #116.

