### PR TITLE
test: Avoid the deprecated TestCase.assertEquals() API

### DIFF
--- a/test.py
+++ b/test.py
@@ -2038,64 +2038,64 @@ class GPXTests(mod_unittest.TestCase):
         namespace = '{https://github.com/tkrajina/gpxpy}'
         for gpx in (original_gpx, reparsed_gpx):
             for dom in (original_dom, reparsed_dom):
-                self.assertEquals(gpx.version, '1.1')
-                self.assertEquals(get_dom_node(dom, 'gpx').attributes['version'].nodeValue, '1.1')
+                self.assertEqual(gpx.version, '1.1')
+                self.assertEqual(get_dom_node(dom, 'gpx').attributes['version'].nodeValue, '1.1')
 
-                self.assertEquals(gpx.creator, '...')
-                self.assertEquals(get_dom_node(dom, 'gpx').attributes['creator'].nodeValue, '...')
+                self.assertEqual(gpx.creator, '...')
+                self.assertEqual(get_dom_node(dom, 'gpx').attributes['creator'].nodeValue, '...')
 
-                self.assertEquals(gpx.name, 'example name')
-                self.assertEquals(get_dom_node(dom, 'gpx/metadata/name').firstChild.nodeValue, 'example name')
+                self.assertEqual(gpx.name, 'example name')
+                self.assertEqual(get_dom_node(dom, 'gpx/metadata/name').firstChild.nodeValue, 'example name')
 
-                self.assertEquals(gpx.description, 'example description')
-                self.assertEquals(get_dom_node(dom, 'gpx/metadata/desc').firstChild.nodeValue, 'example description')
+                self.assertEqual(gpx.description, 'example description')
+                self.assertEqual(get_dom_node(dom, 'gpx/metadata/desc').firstChild.nodeValue, 'example description')
 
-                self.assertEquals(gpx.author_name, 'author name')
-                self.assertEquals(get_dom_node(dom, 'gpx/metadata/author/name').firstChild.nodeValue, 'author name')
+                self.assertEqual(gpx.author_name, 'author name')
+                self.assertEqual(get_dom_node(dom, 'gpx/metadata/author/name').firstChild.nodeValue, 'author name')
 
-                self.assertEquals(gpx.author_email, 'aaa@bbb.com')
-                self.assertEquals(get_dom_node(dom, 'gpx/metadata/author/email').attributes['id'].nodeValue, 'aaa')
-                self.assertEquals(get_dom_node(dom, 'gpx/metadata/author/email').attributes['domain'].nodeValue, 'bbb.com')
+                self.assertEqual(gpx.author_email, 'aaa@bbb.com')
+                self.assertEqual(get_dom_node(dom, 'gpx/metadata/author/email').attributes['id'].nodeValue, 'aaa')
+                self.assertEqual(get_dom_node(dom, 'gpx/metadata/author/email').attributes['domain'].nodeValue, 'bbb.com')
 
-                self.assertEquals(gpx.author_link, 'http://link')
-                self.assertEquals(get_dom_node(dom, 'gpx/metadata/author/link').attributes['href'].nodeValue, 'http://link')
+                self.assertEqual(gpx.author_link, 'http://link')
+                self.assertEqual(get_dom_node(dom, 'gpx/metadata/author/link').attributes['href'].nodeValue, 'http://link')
 
-                self.assertEquals(gpx.author_link_text, 'link text')
-                self.assertEquals(get_dom_node(dom, 'gpx/metadata/author/link/text').firstChild.nodeValue, 'link text')
+                self.assertEqual(gpx.author_link_text, 'link text')
+                self.assertEqual(get_dom_node(dom, 'gpx/metadata/author/link/text').firstChild.nodeValue, 'link text')
 
-                self.assertEquals(gpx.author_link_type, 'link type')
-                self.assertEquals(get_dom_node(dom, 'gpx/metadata/author/link/type').firstChild.nodeValue, 'link type')
+                self.assertEqual(gpx.author_link_type, 'link type')
+                self.assertEqual(get_dom_node(dom, 'gpx/metadata/author/link/type').firstChild.nodeValue, 'link type')
 
-                self.assertEquals(gpx.copyright_author, 'gpxauth')
-                self.assertEquals(get_dom_node(dom, 'gpx/metadata/copyright').attributes['author'].nodeValue, 'gpxauth')
+                self.assertEqual(gpx.copyright_author, 'gpxauth')
+                self.assertEqual(get_dom_node(dom, 'gpx/metadata/copyright').attributes['author'].nodeValue, 'gpxauth')
 
-                self.assertEquals(gpx.copyright_year, '2013')
-                self.assertEquals(get_dom_node(dom, 'gpx/metadata/copyright/year').firstChild.nodeValue, '2013')
+                self.assertEqual(gpx.copyright_year, '2013')
+                self.assertEqual(get_dom_node(dom, 'gpx/metadata/copyright/year').firstChild.nodeValue, '2013')
 
-                self.assertEquals(gpx.copyright_license, 'lic')
-                self.assertEquals(get_dom_node(dom, 'gpx/metadata/copyright/license').firstChild.nodeValue, 'lic')
+                self.assertEqual(gpx.copyright_license, 'lic')
+                self.assertEqual(get_dom_node(dom, 'gpx/metadata/copyright/license').firstChild.nodeValue, 'lic')
 
-                self.assertEquals(gpx.link, 'http://link2')
-                self.assertEquals(get_dom_node(dom, 'gpx/metadata/link').attributes['href'].nodeValue, 'http://link2')
+                self.assertEqual(gpx.link, 'http://link2')
+                self.assertEqual(get_dom_node(dom, 'gpx/metadata/link').attributes['href'].nodeValue, 'http://link2')
 
-                self.assertEquals(gpx.link_text, 'link text2')
-                self.assertEquals(get_dom_node(dom, 'gpx/metadata/link/text').firstChild.nodeValue, 'link text2')
+                self.assertEqual(gpx.link_text, 'link text2')
+                self.assertEqual(get_dom_node(dom, 'gpx/metadata/link/text').firstChild.nodeValue, 'link text2')
 
-                self.assertEquals(gpx.link_type, 'link type2')
-                self.assertEquals(get_dom_node(dom, 'gpx/metadata/link/type').firstChild.nodeValue, 'link type2')
+                self.assertEqual(gpx.link_type, 'link type2')
+                self.assertEqual(get_dom_node(dom, 'gpx/metadata/link/type').firstChild.nodeValue, 'link type2')
 
-                self.assertEquals(gpx.time, mod_datetime.datetime(2013, 1, 1, 12, 0))
+                self.assertEqual(gpx.time, mod_datetime.datetime(2013, 1, 1, 12, 0))
                 self.assertTrue(get_dom_node(dom, 'gpx/metadata/time').firstChild.nodeValue in ('2013-01-01T12:00:00Z', '2013-01-01T12:00:00'))
 
-                self.assertEquals(gpx.keywords, 'example keywords')
-                self.assertEquals(get_dom_node(dom, 'gpx/metadata/keywords').firstChild.nodeValue, 'example keywords')
+                self.assertEqual(gpx.keywords, 'example keywords')
+                self.assertEqual(get_dom_node(dom, 'gpx/metadata/keywords').firstChild.nodeValue, 'example keywords')
 
-                self.assertEquals(gpx.bounds.min_latitude, 1.2)
-                self.assertEquals(get_dom_node(dom, 'gpx/metadata/bounds').attributes['minlat'].value, '1.2')
+                self.assertEqual(gpx.bounds.min_latitude, 1.2)
+                self.assertEqual(get_dom_node(dom, 'gpx/metadata/bounds').attributes['minlat'].value, '1.2')
 
                 # TODO
 
-                self.assertEquals(len(gpx.metadata_extensions), 3)
+                self.assertEqual(len(gpx.metadata_extensions), 3)
                 aaa = mod_etree.Element(namespace+'aaa')
                 aaa.text = 'bbb'
                 aaa.tail = ''
@@ -2110,95 +2110,95 @@ class GPXTests(mod_unittest.TestCase):
                 self.assertTrue(elements_equal(gpx.metadata_extensions[2], ccc))
 
                 # get_dom_node function is not escaped and so fails on proper namespaces
-                #self.assertEquals(get_dom_node(dom, 'gpx/metadata/extensions/{}aaa'.format(namespace)).firstChild.nodeValue, 'bbb')
-                #self.assertEquals(get_dom_node(dom, 'gpx/metadata/extensions/bbb').firstChild.nodeValue, 'ccc')
-                #self.assertEquals(get_dom_node(dom, 'gpx/metadata/extensions/ccc').firstChild.nodeValue, 'ddd')
+                #self.assertEqual(get_dom_node(dom, 'gpx/metadata/extensions/{}aaa'.format(namespace)).firstChild.nodeValue, 'bbb')
+                #self.assertEqual(get_dom_node(dom, 'gpx/metadata/extensions/bbb').firstChild.nodeValue, 'ccc')
+                #self.assertEqual(get_dom_node(dom, 'gpx/metadata/extensions/ccc').firstChild.nodeValue, 'ddd')
 
-                self.assertEquals(2, len(gpx.waypoints))
+                self.assertEqual(2, len(gpx.waypoints))
 
-                self.assertEquals(gpx.waypoints[0].latitude, 12.3)
-                self.assertEquals(get_dom_node(dom, 'gpx/wpt[0]').attributes['lat'].value, '12.3')
+                self.assertEqual(gpx.waypoints[0].latitude, 12.3)
+                self.assertEqual(get_dom_node(dom, 'gpx/wpt[0]').attributes['lat'].value, '12.3')
 
-                self.assertEquals(gpx.waypoints[0].longitude, 45.6)
-                self.assertEquals(get_dom_node(dom, 'gpx/wpt[0]').attributes['lon'].value, '45.6')
+                self.assertEqual(gpx.waypoints[0].longitude, 45.6)
+                self.assertEqual(get_dom_node(dom, 'gpx/wpt[0]').attributes['lon'].value, '45.6')
 
-                self.assertEquals(gpx.waypoints[0].longitude, 45.6)
-                self.assertEquals(get_dom_node(dom, 'gpx/wpt[0]').attributes['lon'].value, '45.6')
+                self.assertEqual(gpx.waypoints[0].longitude, 45.6)
+                self.assertEqual(get_dom_node(dom, 'gpx/wpt[0]').attributes['lon'].value, '45.6')
 
-                self.assertEquals(gpx.waypoints[0].elevation, 75.1)
-                self.assertEquals(get_dom_node(dom, 'gpx/wpt[0]/ele').firstChild.nodeValue, '75.1')
+                self.assertEqual(gpx.waypoints[0].elevation, 75.1)
+                self.assertEqual(get_dom_node(dom, 'gpx/wpt[0]/ele').firstChild.nodeValue, '75.1')
 
-                self.assertEquals(gpx.waypoints[0].time, mod_datetime.datetime(2013, 1, 2, 2, 3))
-                self.assertEquals(get_dom_node(dom, 'gpx/wpt[0]/time').firstChild.nodeValue, '2013-01-02T02:03:00Z')
+                self.assertEqual(gpx.waypoints[0].time, mod_datetime.datetime(2013, 1, 2, 2, 3))
+                self.assertEqual(get_dom_node(dom, 'gpx/wpt[0]/time').firstChild.nodeValue, '2013-01-02T02:03:00Z')
 
-                self.assertEquals(gpx.waypoints[0].magnetic_variation, 1.1)
-                self.assertEquals(get_dom_node(dom, 'gpx/wpt[0]/magvar').firstChild.nodeValue, '1.1')
+                self.assertEqual(gpx.waypoints[0].magnetic_variation, 1.1)
+                self.assertEqual(get_dom_node(dom, 'gpx/wpt[0]/magvar').firstChild.nodeValue, '1.1')
 
-                self.assertEquals(gpx.waypoints[0].geoid_height, 2.0)
-                self.assertEquals(get_dom_node(dom, 'gpx/wpt[0]/geoidheight').firstChild.nodeValue, '2.0')
+                self.assertEqual(gpx.waypoints[0].geoid_height, 2.0)
+                self.assertEqual(get_dom_node(dom, 'gpx/wpt[0]/geoidheight').firstChild.nodeValue, '2.0')
 
-                self.assertEquals(gpx.waypoints[0].name, 'example name')
-                self.assertEquals(get_dom_node(dom, 'gpx/wpt[0]/name').firstChild.nodeValue, 'example name')
+                self.assertEqual(gpx.waypoints[0].name, 'example name')
+                self.assertEqual(get_dom_node(dom, 'gpx/wpt[0]/name').firstChild.nodeValue, 'example name')
 
-                self.assertEquals(gpx.waypoints[0].comment, 'example cmt')
-                self.assertEquals(get_dom_node(dom, 'gpx/wpt[0]/cmt').firstChild.nodeValue, 'example cmt')
+                self.assertEqual(gpx.waypoints[0].comment, 'example cmt')
+                self.assertEqual(get_dom_node(dom, 'gpx/wpt[0]/cmt').firstChild.nodeValue, 'example cmt')
 
-                self.assertEquals(gpx.waypoints[0].description, 'example desc')
-                self.assertEquals(get_dom_node(dom, 'gpx/wpt[0]/desc').firstChild.nodeValue, 'example desc')
+                self.assertEqual(gpx.waypoints[0].description, 'example desc')
+                self.assertEqual(get_dom_node(dom, 'gpx/wpt[0]/desc').firstChild.nodeValue, 'example desc')
 
-                self.assertEquals(gpx.waypoints[0].source, 'example src')
-                self.assertEquals(get_dom_node(dom, 'gpx/wpt[0]/src').firstChild.nodeValue, 'example src')
+                self.assertEqual(gpx.waypoints[0].source, 'example src')
+                self.assertEqual(get_dom_node(dom, 'gpx/wpt[0]/src').firstChild.nodeValue, 'example src')
 
-                self.assertEquals(gpx.waypoints[0].link, 'http://link3')
-                self.assertEquals(get_dom_node(dom, 'gpx/wpt[0]/link').attributes['href'].nodeValue, 'http://link3')
+                self.assertEqual(gpx.waypoints[0].link, 'http://link3')
+                self.assertEqual(get_dom_node(dom, 'gpx/wpt[0]/link').attributes['href'].nodeValue, 'http://link3')
 
-                self.assertEquals(gpx.waypoints[0].link_text, 'link text3')
-                self.assertEquals(get_dom_node(dom, 'gpx/wpt[0]/link/text').firstChild.nodeValue, 'link text3')
+                self.assertEqual(gpx.waypoints[0].link_text, 'link text3')
+                self.assertEqual(get_dom_node(dom, 'gpx/wpt[0]/link/text').firstChild.nodeValue, 'link text3')
 
-                self.assertEquals(gpx.waypoints[0].link_type, 'link type3')
-                self.assertEquals(get_dom_node(dom, 'gpx/wpt[0]/link/type').firstChild.nodeValue, 'link type3')
+                self.assertEqual(gpx.waypoints[0].link_type, 'link type3')
+                self.assertEqual(get_dom_node(dom, 'gpx/wpt[0]/link/type').firstChild.nodeValue, 'link type3')
 
-                self.assertEquals(gpx.waypoints[1].latitude, 13.4)
-                self.assertEquals(get_dom_node(dom, 'gpx/wpt[1]').attributes['lat'].value, '13.4')
+                self.assertEqual(gpx.waypoints[1].latitude, 13.4)
+                self.assertEqual(get_dom_node(dom, 'gpx/wpt[1]').attributes['lat'].value, '13.4')
 
-                self.assertEquals(gpx.waypoints[1].longitude, 46.7)
-                self.assertEquals(get_dom_node(dom, 'gpx/wpt[1]').attributes['lon'].value, '46.7')
+                self.assertEqual(gpx.waypoints[1].longitude, 46.7)
+                self.assertEqual(get_dom_node(dom, 'gpx/wpt[1]').attributes['lon'].value, '46.7')
 
-                self.assertEquals(2, len(gpx.waypoints[0].extensions))
+                self.assertEqual(2, len(gpx.waypoints[0].extensions))
 
                 self.assertTrue(elements_equal(gpx.waypoints[0].extensions[0], aaa))
                 self.assertTrue(elements_equal(gpx.waypoints[0].extensions[1], ccc))
 
                 # 1. rte
 
-                self.assertEquals(gpx.routes[0].name, 'example name')
-                self.assertEquals(get_dom_node(dom, 'gpx/rte[0]/name').firstChild.nodeValue, 'example name')
+                self.assertEqual(gpx.routes[0].name, 'example name')
+                self.assertEqual(get_dom_node(dom, 'gpx/rte[0]/name').firstChild.nodeValue, 'example name')
 
-                self.assertEquals(gpx.routes[0].comment, 'example cmt')
-                self.assertEquals(get_dom_node(dom, 'gpx/rte[0]/cmt').firstChild.nodeValue, 'example cmt')
+                self.assertEqual(gpx.routes[0].comment, 'example cmt')
+                self.assertEqual(get_dom_node(dom, 'gpx/rte[0]/cmt').firstChild.nodeValue, 'example cmt')
 
-                self.assertEquals(gpx.routes[0].description, 'example desc')
-                self.assertEquals(get_dom_node(dom, 'gpx/rte[0]/desc').firstChild.nodeValue, 'example desc')
+                self.assertEqual(gpx.routes[0].description, 'example desc')
+                self.assertEqual(get_dom_node(dom, 'gpx/rte[0]/desc').firstChild.nodeValue, 'example desc')
 
-                self.assertEquals(gpx.routes[0].source, 'example src')
-                self.assertEquals(get_dom_node(dom, 'gpx/rte[0]/src').firstChild.nodeValue, 'example src')
+                self.assertEqual(gpx.routes[0].source, 'example src')
+                self.assertEqual(get_dom_node(dom, 'gpx/rte[0]/src').firstChild.nodeValue, 'example src')
 
-                self.assertEquals(gpx.routes[0].link, 'http://link3')
-                self.assertEquals(get_dom_node(dom, 'gpx/rte[0]/link').attributes['href'].nodeValue, 'http://link3')
+                self.assertEqual(gpx.routes[0].link, 'http://link3')
+                self.assertEqual(get_dom_node(dom, 'gpx/rte[0]/link').attributes['href'].nodeValue, 'http://link3')
 
-                self.assertEquals(gpx.routes[0].link_text, 'link text3')
-                self.assertEquals(get_dom_node(dom, 'gpx/rte[0]/link/text').firstChild.nodeValue, 'link text3')
+                self.assertEqual(gpx.routes[0].link_text, 'link text3')
+                self.assertEqual(get_dom_node(dom, 'gpx/rte[0]/link/text').firstChild.nodeValue, 'link text3')
 
-                self.assertEquals(gpx.routes[0].link_type, 'link type3')
-                self.assertEquals(get_dom_node(dom, 'gpx/rte[0]/link/type').firstChild.nodeValue, 'link type3')
+                self.assertEqual(gpx.routes[0].link_type, 'link type3')
+                self.assertEqual(get_dom_node(dom, 'gpx/rte[0]/link/type').firstChild.nodeValue, 'link type3')
 
-                self.assertEquals(gpx.routes[0].number, 7)
-                self.assertEquals(get_dom_node(dom, 'gpx/rte[0]/number').firstChild.nodeValue, '7')
+                self.assertEqual(gpx.routes[0].number, 7)
+                self.assertEqual(get_dom_node(dom, 'gpx/rte[0]/number').firstChild.nodeValue, '7')
 
-                self.assertEquals(gpx.routes[0].type, 'rte type')
-                self.assertEquals(get_dom_node(dom, 'gpx/rte[0]/type').firstChild.nodeValue, 'rte type')
+                self.assertEqual(gpx.routes[0].type, 'rte type')
+                self.assertEqual(get_dom_node(dom, 'gpx/rte[0]/type').firstChild.nodeValue, 'rte type')
 
-                self.assertEquals(2, len(gpx.routes[0].extensions))
+                self.assertEqual(2, len(gpx.routes[0].extensions))
 
                 rtee1 = mod_etree.Element(namespace+'rtee1')
                 rtee1.text = '1'
@@ -2212,98 +2212,98 @@ class GPXTests(mod_unittest.TestCase):
 
                 # 2. rte
 
-                self.assertEquals(gpx.routes[1].name, 'second route')
-                self.assertEquals(get_dom_node(dom, 'gpx/rte[1]/name').firstChild.nodeValue, 'second route')
+                self.assertEqual(gpx.routes[1].name, 'second route')
+                self.assertEqual(get_dom_node(dom, 'gpx/rte[1]/name').firstChild.nodeValue, 'second route')
 
-                self.assertEquals(gpx.routes[1].description, 'example desc 2')
-                self.assertEquals(get_dom_node(dom, 'gpx/rte[1]/desc').firstChild.nodeValue, 'example desc 2')
+                self.assertEqual(gpx.routes[1].description, 'example desc 2')
+                self.assertEqual(get_dom_node(dom, 'gpx/rte[1]/desc').firstChild.nodeValue, 'example desc 2')
 
-                self.assertEquals(gpx.routes[1].link, None)
+                self.assertEqual(gpx.routes[1].link, None)
 
-                self.assertEquals(gpx.routes[0].number, 7)
-                self.assertEquals(get_dom_node(dom, 'gpx/rte[0]/number').firstChild.nodeValue, '7')
+                self.assertEqual(gpx.routes[0].number, 7)
+                self.assertEqual(get_dom_node(dom, 'gpx/rte[0]/number').firstChild.nodeValue, '7')
 
-                self.assertEquals(len(gpx.routes[0].points), 3)
-                self.assertEquals(len(gpx.routes[1].points), 2)
+                self.assertEqual(len(gpx.routes[0].points), 3)
+                self.assertEqual(len(gpx.routes[1].points), 2)
 
                 # Rtept
 
-                self.assertEquals(gpx.routes[0].points[0].latitude, 10)
+                self.assertEqual(gpx.routes[0].points[0].latitude, 10)
                 self.assertTrue(get_dom_node(dom, 'gpx/rte[0]/rtept[0]').attributes['lat'].value in ('10.0', '10'))
 
-                self.assertEquals(gpx.routes[0].points[0].longitude, 20)
+                self.assertEqual(gpx.routes[0].points[0].longitude, 20)
                 self.assertTrue(get_dom_node(dom, 'gpx/rte[0]/rtept[0]').attributes['lon'].value in ('20.0', '20'))
 
-                self.assertEquals(gpx.routes[0].points[0].elevation, 75.1)
-                self.assertEquals(get_dom_node(dom, 'gpx/rte[0]/rtept[0]/ele').firstChild.nodeValue, '75.1')
+                self.assertEqual(gpx.routes[0].points[0].elevation, 75.1)
+                self.assertEqual(get_dom_node(dom, 'gpx/rte[0]/rtept[0]/ele').firstChild.nodeValue, '75.1')
 
-                self.assertEquals(gpx.routes[0].points[0].time, mod_datetime.datetime(2013, 1, 2, 2, 3, 3))
-                self.assertEquals(get_dom_node(dom, 'gpx/rte[0]/rtept[0]/time').firstChild.nodeValue, '2013-01-02T02:03:03Z')
+                self.assertEqual(gpx.routes[0].points[0].time, mod_datetime.datetime(2013, 1, 2, 2, 3, 3))
+                self.assertEqual(get_dom_node(dom, 'gpx/rte[0]/rtept[0]/time').firstChild.nodeValue, '2013-01-02T02:03:03Z')
 
-                self.assertEquals(gpx.routes[0].points[0].magnetic_variation, 1.2)
-                self.assertEquals(get_dom_node(dom, 'gpx/rte[0]/rtept[0]/magvar').firstChild.nodeValue, '1.2')
+                self.assertEqual(gpx.routes[0].points[0].magnetic_variation, 1.2)
+                self.assertEqual(get_dom_node(dom, 'gpx/rte[0]/rtept[0]/magvar').firstChild.nodeValue, '1.2')
 
-                self.assertEquals(gpx.routes[0].points[0].geoid_height, 2.1)
-                self.assertEquals(get_dom_node(dom, 'gpx/rte[0]/rtept[0]/geoidheight').firstChild.nodeValue, '2.1')
+                self.assertEqual(gpx.routes[0].points[0].geoid_height, 2.1)
+                self.assertEqual(get_dom_node(dom, 'gpx/rte[0]/rtept[0]/geoidheight').firstChild.nodeValue, '2.1')
 
-                self.assertEquals(gpx.routes[0].points[0].name, 'example name r')
-                self.assertEquals(get_dom_node(dom, 'gpx/rte[0]/rtept[0]/name').firstChild.nodeValue, 'example name r')
+                self.assertEqual(gpx.routes[0].points[0].name, 'example name r')
+                self.assertEqual(get_dom_node(dom, 'gpx/rte[0]/rtept[0]/name').firstChild.nodeValue, 'example name r')
 
-                self.assertEquals(gpx.routes[0].points[0].comment, 'example cmt r')
-                self.assertEquals(get_dom_node(dom, 'gpx/rte[0]/rtept[0]/cmt').firstChild.nodeValue, 'example cmt r')
+                self.assertEqual(gpx.routes[0].points[0].comment, 'example cmt r')
+                self.assertEqual(get_dom_node(dom, 'gpx/rte[0]/rtept[0]/cmt').firstChild.nodeValue, 'example cmt r')
 
-                self.assertEquals(gpx.routes[0].points[0].description, 'example desc r')
-                self.assertEquals(get_dom_node(dom, 'gpx/rte[0]/rtept[0]/desc').firstChild.nodeValue, 'example desc r')
+                self.assertEqual(gpx.routes[0].points[0].description, 'example desc r')
+                self.assertEqual(get_dom_node(dom, 'gpx/rte[0]/rtept[0]/desc').firstChild.nodeValue, 'example desc r')
 
-                self.assertEquals(gpx.routes[0].points[0].source, 'example src r')
-                self.assertEquals(get_dom_node(dom, 'gpx/rte[0]/rtept[0]/src').firstChild.nodeValue, 'example src r')
+                self.assertEqual(gpx.routes[0].points[0].source, 'example src r')
+                self.assertEqual(get_dom_node(dom, 'gpx/rte[0]/rtept[0]/src').firstChild.nodeValue, 'example src r')
 
-                self.assertEquals(gpx.routes[0].points[0].link, 'http://linkrtept')
-                self.assertEquals(get_dom_node(dom, 'gpx/rte[0]/rtept[0]/link').attributes['href'].nodeValue, 'http://linkrtept')
+                self.assertEqual(gpx.routes[0].points[0].link, 'http://linkrtept')
+                self.assertEqual(get_dom_node(dom, 'gpx/rte[0]/rtept[0]/link').attributes['href'].nodeValue, 'http://linkrtept')
 
-                self.assertEquals(gpx.routes[0].points[0].link_text, 'rtept link')
-                self.assertEquals(get_dom_node(dom, 'gpx/rte[0]/rtept[0]/link/text').firstChild.nodeValue, 'rtept link')
+                self.assertEqual(gpx.routes[0].points[0].link_text, 'rtept link')
+                self.assertEqual(get_dom_node(dom, 'gpx/rte[0]/rtept[0]/link/text').firstChild.nodeValue, 'rtept link')
 
-                self.assertEquals(gpx.routes[0].points[0].link_type, 'rtept link type')
-                self.assertEquals(get_dom_node(dom, 'gpx/rte[0]/rtept[0]/link/type').firstChild.nodeValue, 'rtept link type')
+                self.assertEqual(gpx.routes[0].points[0].link_type, 'rtept link type')
+                self.assertEqual(get_dom_node(dom, 'gpx/rte[0]/rtept[0]/link/type').firstChild.nodeValue, 'rtept link type')
 
-                self.assertEquals(gpx.routes[0].points[0].symbol, 'example sym r')
-                self.assertEquals(get_dom_node(dom, 'gpx/rte[0]/rtept[0]/sym').firstChild.nodeValue, 'example sym r')
+                self.assertEqual(gpx.routes[0].points[0].symbol, 'example sym r')
+                self.assertEqual(get_dom_node(dom, 'gpx/rte[0]/rtept[0]/sym').firstChild.nodeValue, 'example sym r')
 
-                self.assertEquals(gpx.routes[0].points[0].type, 'example type r')
-                self.assertEquals(get_dom_node(dom, 'gpx/rte[0]/rtept[0]/type').firstChild.nodeValue, 'example type r')
+                self.assertEqual(gpx.routes[0].points[0].type, 'example type r')
+                self.assertEqual(get_dom_node(dom, 'gpx/rte[0]/rtept[0]/type').firstChild.nodeValue, 'example type r')
 
-                self.assertEquals(gpx.routes[0].points[0].type_of_gpx_fix, '3d')
-                self.assertEquals(get_dom_node(dom, 'gpx/rte[0]/rtept[0]/fix').firstChild.nodeValue, '3d')
+                self.assertEqual(gpx.routes[0].points[0].type_of_gpx_fix, '3d')
+                self.assertEqual(get_dom_node(dom, 'gpx/rte[0]/rtept[0]/fix').firstChild.nodeValue, '3d')
 
-                self.assertEquals(gpx.routes[0].points[0].satellites, 6)
-                self.assertEquals(get_dom_node(dom, 'gpx/rte[0]/rtept[0]/sat').firstChild.nodeValue, '6')
+                self.assertEqual(gpx.routes[0].points[0].satellites, 6)
+                self.assertEqual(get_dom_node(dom, 'gpx/rte[0]/rtept[0]/sat').firstChild.nodeValue, '6')
 
-                self.assertEquals(gpx.routes[0].points[0].vertical_dilution, 8)
+                self.assertEqual(gpx.routes[0].points[0].vertical_dilution, 8)
                 self.assertTrue(get_dom_node(dom, 'gpx/rte[0]/rtept[0]/vdop').firstChild.nodeValue in ('8.0', '8'))
 
-                self.assertEquals(gpx.routes[0].points[0].horizontal_dilution, 7)
+                self.assertEqual(gpx.routes[0].points[0].horizontal_dilution, 7)
                 self.assertTrue(get_dom_node(dom, 'gpx/rte[0]/rtept[0]/hdop').firstChild.nodeValue in ('7.0', '7'))
 
-                self.assertEquals(gpx.routes[0].points[0].position_dilution, 9)
+                self.assertEqual(gpx.routes[0].points[0].position_dilution, 9)
                 self.assertTrue(get_dom_node(dom, 'gpx/rte[0]/rtept[0]/pdop').firstChild.nodeValue in ('9.0', '9'))
 
-                self.assertEquals(gpx.routes[0].points[0].age_of_dgps_data, 10)
+                self.assertEqual(gpx.routes[0].points[0].age_of_dgps_data, 10)
                 self.assertTrue(get_dom_node(dom, 'gpx/rte[0]/rtept[0]/ageofdgpsdata').firstChild.nodeValue in ('10.0', '10'))
 
-                self.assertEquals(gpx.routes[0].points[0].dgps_id, '99')
-                self.assertEquals(get_dom_node(dom, 'gpx/rte[0]/rtept[0]/dgpsid').firstChild.nodeValue, '99')
+                self.assertEqual(gpx.routes[0].points[0].dgps_id, '99')
+                self.assertEqual(get_dom_node(dom, 'gpx/rte[0]/rtept[0]/dgpsid').firstChild.nodeValue, '99')
 
                 # second rtept:
 
-                self.assertEquals(gpx.routes[0].points[1].latitude, 11)
+                self.assertEqual(gpx.routes[0].points[1].latitude, 11)
                 self.assertTrue(get_dom_node(dom, 'gpx/rte[0]/rtept[1]').attributes['lat'].value in ('11.0', '11'))
 
-                self.assertEquals(gpx.routes[0].points[1].longitude, 21)
+                self.assertEqual(gpx.routes[0].points[1].longitude, 21)
                 self.assertTrue(get_dom_node(dom, 'gpx/rte[0]/rtept[1]').attributes['lon'].value in ('21.0', '21'))
 
                 # gpx ext:
-                self.assertEquals(1, len(gpx.extensions))
+                self.assertEqual(1, len(gpx.extensions))
                 gpxext = mod_etree.Element(namespace+'gpxext')
                 gpxext.text = '...'
                 gpxext.tail = ''
@@ -2311,36 +2311,36 @@ class GPXTests(mod_unittest.TestCase):
 
                 # trk
 
-                self.assertEquals(len(gpx.tracks), 2)
+                self.assertEqual(len(gpx.tracks), 2)
 
-                self.assertEquals(gpx.tracks[0].name, 'example name t')
-                self.assertEquals(get_dom_node(dom, 'gpx/trk[0]/name').firstChild.nodeValue, 'example name t')
+                self.assertEqual(gpx.tracks[0].name, 'example name t')
+                self.assertEqual(get_dom_node(dom, 'gpx/trk[0]/name').firstChild.nodeValue, 'example name t')
 
-                self.assertEquals(gpx.tracks[0].comment, 'example cmt t')
-                self.assertEquals(get_dom_node(dom, 'gpx/trk[0]/cmt').firstChild.nodeValue, 'example cmt t')
+                self.assertEqual(gpx.tracks[0].comment, 'example cmt t')
+                self.assertEqual(get_dom_node(dom, 'gpx/trk[0]/cmt').firstChild.nodeValue, 'example cmt t')
 
-                self.assertEquals(gpx.tracks[0].description, 'example desc t')
-                self.assertEquals(get_dom_node(dom, 'gpx/trk[0]/desc').firstChild.nodeValue, 'example desc t')
+                self.assertEqual(gpx.tracks[0].description, 'example desc t')
+                self.assertEqual(get_dom_node(dom, 'gpx/trk[0]/desc').firstChild.nodeValue, 'example desc t')
 
-                self.assertEquals(gpx.tracks[0].source, 'example src t')
-                self.assertEquals(get_dom_node(dom, 'gpx/trk[0]/src').firstChild.nodeValue, 'example src t')
+                self.assertEqual(gpx.tracks[0].source, 'example src t')
+                self.assertEqual(get_dom_node(dom, 'gpx/trk[0]/src').firstChild.nodeValue, 'example src t')
 
-                self.assertEquals(gpx.tracks[0].link, 'http://trk')
-                self.assertEquals(get_dom_node(dom, 'gpx/trk[0]/link').attributes['href'].nodeValue, 'http://trk')
+                self.assertEqual(gpx.tracks[0].link, 'http://trk')
+                self.assertEqual(get_dom_node(dom, 'gpx/trk[0]/link').attributes['href'].nodeValue, 'http://trk')
 
-                self.assertEquals(gpx.tracks[0].link_text, 'trk link')
-                self.assertEquals(get_dom_node(dom, 'gpx/trk[0]/link/text').firstChild.nodeValue, 'trk link')
+                self.assertEqual(gpx.tracks[0].link_text, 'trk link')
+                self.assertEqual(get_dom_node(dom, 'gpx/trk[0]/link/text').firstChild.nodeValue, 'trk link')
 
-                self.assertEquals(gpx.tracks[0].link_type, 'trk link type')
-                self.assertEquals(get_dom_node(dom, 'gpx/trk[0]/link/type').firstChild.nodeValue, 'trk link type')
+                self.assertEqual(gpx.tracks[0].link_type, 'trk link type')
+                self.assertEqual(get_dom_node(dom, 'gpx/trk[0]/link/type').firstChild.nodeValue, 'trk link type')
 
-                self.assertEquals(gpx.tracks[0].number, 1)
-                self.assertEquals(get_dom_node(dom, 'gpx/trk[0]/number').firstChild.nodeValue, '1')
+                self.assertEqual(gpx.tracks[0].number, 1)
+                self.assertEqual(get_dom_node(dom, 'gpx/trk[0]/number').firstChild.nodeValue, '1')
 
-                self.assertEquals(gpx.tracks[0].type, 't')
-                self.assertEquals(get_dom_node(dom, 'gpx/trk[0]/type').firstChild.nodeValue, 't')
+                self.assertEqual(gpx.tracks[0].type, 't')
+                self.assertEqual(get_dom_node(dom, 'gpx/trk[0]/type').firstChild.nodeValue, 't')
 
-                self.assertEquals(1, len(gpx.tracks[0].extensions))
+                self.assertEqual(1, len(gpx.tracks[0].extensions))
                 a1 = mod_etree.Element(namespace+'a1')
                 a1.text = '2'
                 a1.tail = ''
@@ -2349,67 +2349,67 @@ class GPXTests(mod_unittest.TestCase):
 
                 # trkpt:
 
-                self.assertEquals(gpx.tracks[0].segments[0].points[0].elevation, 11.1)
-                self.assertEquals(get_dom_node(dom, 'gpx/trk[0]/trkseg[0]/trkpt[0]/ele').firstChild.nodeValue, '11.1')
+                self.assertEqual(gpx.tracks[0].segments[0].points[0].elevation, 11.1)
+                self.assertEqual(get_dom_node(dom, 'gpx/trk[0]/trkseg[0]/trkpt[0]/ele').firstChild.nodeValue, '11.1')
 
-                self.assertEquals(gpx.tracks[0].segments[0].points[0].time, mod_datetime.datetime(2013, 1, 1, 12, 0, 4))
+                self.assertEqual(gpx.tracks[0].segments[0].points[0].time, mod_datetime.datetime(2013, 1, 1, 12, 0, 4))
                 self.assertTrue(get_dom_node(dom, 'gpx/trk[0]/trkseg[0]/trkpt[0]/time').firstChild.nodeValue in ('2013-01-01T12:00:04Z', '2013-01-01T12:00:04'))
 
-                self.assertEquals(gpx.tracks[0].segments[0].points[0].magnetic_variation, 12)
+                self.assertEqual(gpx.tracks[0].segments[0].points[0].magnetic_variation, 12)
                 self.assertTrue(get_dom_node(dom, 'gpx/trk[0]/trkseg[0]/trkpt[0]/magvar').firstChild.nodeValue in ('12.0', '12'))
 
-                self.assertEquals(gpx.tracks[0].segments[0].points[0].geoid_height, 13.0)
+                self.assertEqual(gpx.tracks[0].segments[0].points[0].geoid_height, 13.0)
                 self.assertTrue(get_dom_node(dom, 'gpx/trk[0]/trkseg[0]/trkpt[0]/geoidheight').firstChild.nodeValue in ('13.0', '13'))
 
-                self.assertEquals(gpx.tracks[0].segments[0].points[0].name, 'example name t')
-                self.assertEquals(get_dom_node(dom, 'gpx/trk[0]/trkseg[0]/trkpt[0]/name').firstChild.nodeValue, 'example name t')
+                self.assertEqual(gpx.tracks[0].segments[0].points[0].name, 'example name t')
+                self.assertEqual(get_dom_node(dom, 'gpx/trk[0]/trkseg[0]/trkpt[0]/name').firstChild.nodeValue, 'example name t')
 
-                self.assertEquals(gpx.tracks[0].segments[0].points[0].comment, 'example cmt t')
-                self.assertEquals(get_dom_node(dom, 'gpx/trk[0]/trkseg[0]/trkpt[0]/cmt').firstChild.nodeValue, 'example cmt t')
+                self.assertEqual(gpx.tracks[0].segments[0].points[0].comment, 'example cmt t')
+                self.assertEqual(get_dom_node(dom, 'gpx/trk[0]/trkseg[0]/trkpt[0]/cmt').firstChild.nodeValue, 'example cmt t')
 
-                self.assertEquals(gpx.tracks[0].segments[0].points[0].description, 'example desc t')
-                self.assertEquals(get_dom_node(dom, 'gpx/trk[0]/trkseg[0]/trkpt[0]/desc').firstChild.nodeValue, 'example desc t')
+                self.assertEqual(gpx.tracks[0].segments[0].points[0].description, 'example desc t')
+                self.assertEqual(get_dom_node(dom, 'gpx/trk[0]/trkseg[0]/trkpt[0]/desc').firstChild.nodeValue, 'example desc t')
 
-                self.assertEquals(gpx.tracks[0].segments[0].points[0].source, 'example src t')
-                self.assertEquals(get_dom_node(dom, 'gpx/trk[0]/trkseg[0]/trkpt[0]/src').firstChild.nodeValue, 'example src t')
+                self.assertEqual(gpx.tracks[0].segments[0].points[0].source, 'example src t')
+                self.assertEqual(get_dom_node(dom, 'gpx/trk[0]/trkseg[0]/trkpt[0]/src').firstChild.nodeValue, 'example src t')
 
-                self.assertEquals(gpx.tracks[0].segments[0].points[0].link, 'http://trkpt')
-                self.assertEquals(get_dom_node(dom, 'gpx/trk[0]/trkseg[0]/trkpt[0]/link').attributes['href'].nodeValue, 'http://trkpt')
+                self.assertEqual(gpx.tracks[0].segments[0].points[0].link, 'http://trkpt')
+                self.assertEqual(get_dom_node(dom, 'gpx/trk[0]/trkseg[0]/trkpt[0]/link').attributes['href'].nodeValue, 'http://trkpt')
 
-                self.assertEquals(gpx.tracks[0].segments[0].points[0].link_text, 'trkpt link')
-                self.assertEquals(get_dom_node(dom, 'gpx/trk[0]/trkseg[0]/trkpt[0]/link/text').firstChild.nodeValue, 'trkpt link')
+                self.assertEqual(gpx.tracks[0].segments[0].points[0].link_text, 'trkpt link')
+                self.assertEqual(get_dom_node(dom, 'gpx/trk[0]/trkseg[0]/trkpt[0]/link/text').firstChild.nodeValue, 'trkpt link')
 
-                self.assertEquals(gpx.tracks[0].segments[0].points[0].link_type, 'trkpt link type')
-                self.assertEquals(get_dom_node(dom, 'gpx/trk[0]/trkseg[0]/trkpt[0]/link/type').firstChild.nodeValue, 'trkpt link type')
+                self.assertEqual(gpx.tracks[0].segments[0].points[0].link_type, 'trkpt link type')
+                self.assertEqual(get_dom_node(dom, 'gpx/trk[0]/trkseg[0]/trkpt[0]/link/type').firstChild.nodeValue, 'trkpt link type')
 
-                self.assertEquals(gpx.tracks[0].segments[0].points[0].symbol, 'example sym t')
-                self.assertEquals(get_dom_node(dom, 'gpx/trk[0]/trkseg[0]/trkpt[0]/sym').firstChild.nodeValue, 'example sym t')
+                self.assertEqual(gpx.tracks[0].segments[0].points[0].symbol, 'example sym t')
+                self.assertEqual(get_dom_node(dom, 'gpx/trk[0]/trkseg[0]/trkpt[0]/sym').firstChild.nodeValue, 'example sym t')
 
-                self.assertEquals(gpx.tracks[0].segments[0].points[0].type, 'example type t')
-                self.assertEquals(get_dom_node(dom, 'gpx/trk[0]/trkseg[0]/trkpt[0]/type').firstChild.nodeValue, 'example type t')
+                self.assertEqual(gpx.tracks[0].segments[0].points[0].type, 'example type t')
+                self.assertEqual(get_dom_node(dom, 'gpx/trk[0]/trkseg[0]/trkpt[0]/type').firstChild.nodeValue, 'example type t')
 
-                self.assertEquals(gpx.tracks[0].segments[0].points[0].type_of_gpx_fix, '3d')
-                self.assertEquals(get_dom_node(dom, 'gpx/trk[0]/trkseg[0]/trkpt[0]/fix').firstChild.nodeValue, '3d')
+                self.assertEqual(gpx.tracks[0].segments[0].points[0].type_of_gpx_fix, '3d')
+                self.assertEqual(get_dom_node(dom, 'gpx/trk[0]/trkseg[0]/trkpt[0]/fix').firstChild.nodeValue, '3d')
 
-                self.assertEquals(gpx.tracks[0].segments[0].points[0].satellites, 100)
-                self.assertEquals(get_dom_node(dom, 'gpx/trk[0]/trkseg[0]/trkpt[0]/sat').firstChild.nodeValue, '100')
+                self.assertEqual(gpx.tracks[0].segments[0].points[0].satellites, 100)
+                self.assertEqual(get_dom_node(dom, 'gpx/trk[0]/trkseg[0]/trkpt[0]/sat').firstChild.nodeValue, '100')
 
-                self.assertEquals(gpx.tracks[0].segments[0].points[0].vertical_dilution, 102.)
+                self.assertEqual(gpx.tracks[0].segments[0].points[0].vertical_dilution, 102.)
                 self.assertTrue(get_dom_node(dom, 'gpx/trk[0]/trkseg[0]/trkpt[0]/vdop').firstChild.nodeValue in ('102.0', '102'))
 
-                self.assertEquals(gpx.tracks[0].segments[0].points[0].horizontal_dilution, 101)
+                self.assertEqual(gpx.tracks[0].segments[0].points[0].horizontal_dilution, 101)
                 self.assertTrue(get_dom_node(dom, 'gpx/trk[0]/trkseg[0]/trkpt[0]/hdop').firstChild.nodeValue in ('101.0', '101'))
 
-                self.assertEquals(gpx.tracks[0].segments[0].points[0].position_dilution, 103)
+                self.assertEqual(gpx.tracks[0].segments[0].points[0].position_dilution, 103)
                 self.assertTrue(get_dom_node(dom, 'gpx/trk[0]/trkseg[0]/trkpt[0]/pdop').firstChild.nodeValue in ('103.0', '103'))
 
-                self.assertEquals(gpx.tracks[0].segments[0].points[0].age_of_dgps_data, 104)
+                self.assertEqual(gpx.tracks[0].segments[0].points[0].age_of_dgps_data, 104)
                 self.assertTrue(get_dom_node(dom, 'gpx/trk[0]/trkseg[0]/trkpt[0]/ageofdgpsdata').firstChild.nodeValue in ('104.0', '104'))
 
-                self.assertEquals(gpx.tracks[0].segments[0].points[0].dgps_id, '99')
-                self.assertEquals(get_dom_node(dom, 'gpx/trk[0]/trkseg[0]/trkpt[0]/dgpsid').firstChild.nodeValue, '99')
+                self.assertEqual(gpx.tracks[0].segments[0].points[0].dgps_id, '99')
+                self.assertEqual(get_dom_node(dom, 'gpx/trk[0]/trkseg[0]/trkpt[0]/dgpsid').firstChild.nodeValue, '99')
 
-                self.assertEquals(1, len(gpx.tracks[0].segments[0].points[0].extensions))
+                self.assertEqual(1, len(gpx.tracks[0].segments[0].points[0].extensions))
                 last = mod_etree.Element(namespace+'last')
                 last.text = 'true'
                 last.tail = ''
@@ -3251,14 +3251,14 @@ class GPXTests(mod_unittest.TestCase):
 </trk>
 </gpx>""")
 
-        self.assertEquals(1, len(gpx.tracks))
-        self.assertEquals(1, len(gpx.tracks[0].segments))
-        self.assertEquals(1, len(gpx.tracks[0].segments[0].points))
+        self.assertEqual(1, len(gpx.tracks))
+        self.assertEqual(1, len(gpx.tracks[0].segments))
+        self.assertEqual(1, len(gpx.tracks[0].segments[0].points))
 
     def test_default_schema_locations(self):
         gpx = mod_gpx.GPX()
         with custom_open('test_files/default_schema_locations.gpx') as f:
-            self.assertEquals(gpx.to_xml(), f.read())
+            self.assertEqual(gpx.to_xml(), f.read())
 
     def test_custom_schema_locations(self):
         gpx = mod_gpx.GPX()
@@ -3272,11 +3272,11 @@ class GPXTests(mod_unittest.TestCase):
            'http://www.garmin.com/xmlschemas/GpxExtensionsv3.xsd',
         ]
         with custom_open('test_files/custom_schema_locations.gpx') as f:
-            self.assertEquals(gpx.to_xml(), f.read())
+            self.assertEqual(gpx.to_xml(), f.read())
 
     def test_parse_custom_schema_locations(self):
         gpx = self.parse('custom_schema_locations.gpx')
-        self.assertEquals(
+        self.assertEqual(
             [
                 'http://www.topografix.com/GPX/1/1',
                 'http://www.topografix.com/GPX/1/1/gpx.xsd',
@@ -3294,9 +3294,9 @@ class GPXTests(mod_unittest.TestCase):
     </extensions>
 </gpx>"""
         gpx = mod_gpxpy.parse(xml)
-        self.assertEquals(0, len(gpx.tracks))
+        self.assertEqual(0, len(gpx.tracks))
         gpx2 = self.reparse(gpx)
-        self.assertEquals(0, len(gpx2.tracks))
+        self.assertEqual(0, len(gpx2.tracks))
 
 class LxmlTest(mod_unittest.TestCase):
     @mod_unittest.skipIf(mod_os.environ.get('XMLPARSER')!="LXML", "LXML not installed")


### PR DESCRIPTION
It has simply been renamed to assertEqual().

Signed-off-by: Francois Gouget <fgouget@free.fr>