### PR TITLE
Update python_requires and upgrade Python syntax

### DIFF
--- a/gpxpy/__init__.py
+++ b/gpxpy/__init__.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # Copyright 2011 Tomo Krajina
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/gpxpy/geo.py
+++ b/gpxpy/geo.py
@@ -319,13 +319,13 @@ class Location:
         return Location(latitude, longitude)
 
     def __str__(self) -> str:
-        return '[loc:{},{}@{}]'.format(self.latitude, self.longitude, self.elevation)
+        return f'[loc:{self.latitude},{self.longitude}@{self.elevation}]'
 
     def __repr__(self) -> str:
         if self.elevation is None:
-            return 'Location({}, {})'.format(self.latitude, self.longitude)
+            return f'Location({self.latitude}, {self.longitude})'
         else:
-            return 'Location({}, {}, {})'.format(self.latitude, self.longitude, self.elevation)
+            return f'Location({self.latitude}, {self.longitude}, {self.elevation})'
 
 
 class LocationDelta:

--- a/gpxpy/geo.py
+++ b/gpxpy/geo.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # Copyright 2011 Tomo Krajina
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/gpxpy/geo.py
+++ b/gpxpy/geo.py
@@ -321,13 +321,13 @@ class Location:
         return Location(latitude, longitude)
 
     def __str__(self) -> str:
-        return '[loc:%s,%s@%s]' % (self.latitude, self.longitude, self.elevation)
+        return '[loc:{},{}@{}]'.format(self.latitude, self.longitude, self.elevation)
 
     def __repr__(self) -> str:
         if self.elevation is None:
-            return 'Location(%s, %s)' % (self.latitude, self.longitude)
+            return 'Location({}, {})'.format(self.latitude, self.longitude)
         else:
-            return 'Location(%s, %s, %s)' % (self.latitude, self.longitude, self.elevation)
+            return 'Location({}, {}, {})'.format(self.latitude, self.longitude, self.elevation)
 
 
 class LocationDelta:

--- a/gpxpy/gpx.py
+++ b/gpxpy/gpx.py
@@ -234,10 +234,10 @@ class GPXWaypoint(mod_geo.Location):
         self.extensions: List[Any] = [] # TODO
 
     def __str__(self) -> str:
-        return '[wpt{{{}}}:{},{}@{}]'.format(self.name, self.latitude, self.longitude, self.elevation)
+        return f'[wpt{{{self.name}}}:{self.latitude},{self.longitude}@{self.elevation}]'
 
     def __repr__(self) -> str:
-        representation = '{}, {}'.format(self.latitude, self.longitude)
+        representation = f'{self.latitude}, {self.longitude}'
         for attribute in 'elevation', 'time', 'name', 'description', 'symbol', 'type', 'comment', \
                 'horizontal_dilution', 'vertical_dilution', 'position_dilution':
             value = getattr(self, attribute)
@@ -309,10 +309,10 @@ class GPXRoutePoint(mod_geo.Location):
         self.extensions: List[Any] = [] # TODO
 
     def __str__(self) -> str:
-        return '[rtept{{{}}}:{},{}@{}]'.format(self.name, self.latitude, self.longitude, self.elevation)
+        return f'[rtept{{{self.name}}}:{self.latitude},{self.longitude}@{self.elevation}]'
 
     def __repr__(self) -> str:
-        representation = '{}, {}'.format(self.latitude, self.longitude)
+        representation = f'{self.latitude}, {self.longitude}'
         for attribute in 'elevation', 'time', 'name', 'description', 'symbol', 'type', 'comment', \
                 'horizontal_dilution', 'vertical_dilution', 'position_dilution':
             value = getattr(self, attribute)
@@ -545,7 +545,7 @@ class GPXTrackPoint(mod_geo.Location):
         self.extensions: List[Any] = []
 
     def __repr__(self) -> str:
-        representation = '{}, {}'.format(self.latitude, self.longitude)
+        representation = f'{self.latitude}, {self.longitude}'
         for attribute in 'elevation', 'time', 'symbol', 'comment', 'horizontal_dilution', \
                 'vertical_dilution', 'position_dilution', 'speed', 'name':
             value = getattr(self, attribute)
@@ -629,7 +629,7 @@ class GPXTrackPoint(mod_geo.Location):
         return length / float(seconds)
 
     def __str__(self) -> str:
-        return '[trkpt:{},{}@{}@{}]'.format(self.latitude, self.longitude, self.elevation, self.time)
+        return f'[trkpt:{self.latitude},{self.longitude}@{self.elevation}@{self.time}]'
 
 
 class GPXTrackSegment:
@@ -1159,7 +1159,7 @@ class GPXTrackSegment:
             return None
 
         if first_time and time and last_time and not first_time <= time <= last_time:
-            log.debug('Not in track (search for:{}, start:{}, end:{})'.format(time, first_time, last_time))
+            log.debug(f'Not in track (search for:{time}, start:{first_time}, end:{last_time})')
             return None
 
         for point in self.points:

--- a/gpxpy/gpx.py
+++ b/gpxpy/gpx.py
@@ -236,15 +236,15 @@ class GPXWaypoint(mod_geo.Location):
         self.extensions: List[Any] = [] # TODO
 
     def __str__(self) -> str:
-        return '[wpt{%s}:%s,%s@%s]' % (self.name, self.latitude, self.longitude, self.elevation)
+        return '[wpt{{{}}}:{},{}@{}]'.format(self.name, self.latitude, self.longitude, self.elevation)
 
     def __repr__(self) -> str:
-        representation = '%s, %s' % (self.latitude, self.longitude)
+        representation = '{}, {}'.format(self.latitude, self.longitude)
         for attribute in 'elevation', 'time', 'name', 'description', 'symbol', 'type', 'comment', \
                 'horizontal_dilution', 'vertical_dilution', 'position_dilution':
             value = getattr(self, attribute)
             if value is not None:
-                representation += ', %s=%s' % (attribute, repr(value))
+                representation += ', {}={}'.format(attribute, repr(value))
         return 'GPXWaypoint(%s)' % representation
 
     def adjust_time(self, delta: mod_datetime.timedelta) -> None:
@@ -311,15 +311,15 @@ class GPXRoutePoint(mod_geo.Location):
         self.extensions: List[Any] = [] # TODO
 
     def __str__(self) -> str:
-        return '[rtept{%s}:%s,%s@%s]' % (self.name, self.latitude, self.longitude, self.elevation)
+        return '[rtept{{{}}}:{},{}@{}]'.format(self.name, self.latitude, self.longitude, self.elevation)
 
     def __repr__(self) -> str:
-        representation = '%s, %s' % (self.latitude, self.longitude)
+        representation = '{}, {}'.format(self.latitude, self.longitude)
         for attribute in 'elevation', 'time', 'name', 'description', 'symbol', 'type', 'comment', \
                 'horizontal_dilution', 'vertical_dilution', 'position_dilution':
             value = getattr(self, attribute)
             if value is not None:
-                representation += ', %s=%s' % (attribute, repr(value))
+                representation += ', {}={}'.format(attribute, repr(value))
         return 'GPXRoutePoint(%s)' % representation
 
     def adjust_time(self, delta: mod_datetime.timedelta) -> None:
@@ -500,8 +500,8 @@ class GPXRoute:
         for attribute in 'name', 'description', 'number':
             value = getattr(self, attribute)
             if value is not None:
-                representation += '%s%s=%s' % (', ' if representation else '', attribute, repr(value))
-        representation += '%spoints=[%s])' % (', ' if representation else '', '...' if self.points else '')
+                representation += '{}{}={}'.format(', ' if representation else '', attribute, repr(value))
+        representation += '{}points=[{}])'.format(', ' if representation else '', '...' if self.points else '')
         return 'GPXRoute(%s)' % representation
 
 
@@ -547,12 +547,12 @@ class GPXTrackPoint(mod_geo.Location):
         self.extensions: List[Any] = []
 
     def __repr__(self) -> str:
-        representation = '%s, %s' % (self.latitude, self.longitude)
+        representation = '{}, {}'.format(self.latitude, self.longitude)
         for attribute in 'elevation', 'time', 'symbol', 'comment', 'horizontal_dilution', \
                 'vertical_dilution', 'position_dilution', 'speed', 'name':
             value = getattr(self, attribute)
             if value is not None:
-                representation += ', %s=%s' % (attribute, repr(value))
+                representation += ', {}={}'.format(attribute, repr(value))
         return 'GPXTrackPoint(%s)' % representation
 
     def adjust_time(self, delta: mod_datetime.timedelta) -> None:
@@ -631,7 +631,7 @@ class GPXTrackPoint(mod_geo.Location):
         return length / float(seconds)
 
     def __str__(self) -> str:
-        return '[trkpt:%s,%s@%s@%s]' % (self.latitude, self.longitude, self.elevation, self.time)
+        return '[trkpt:{},{}@{}@{}]'.format(self.latitude, self.longitude, self.elevation, self.time)
 
 
 class GPXTrackSegment:
@@ -1161,7 +1161,7 @@ class GPXTrackSegment:
             return None
 
         if first_time and time and last_time and not first_time <= time <= last_time:
-            log.debug('Not in track (search for:%s, start:%s, end:%s)' % (time, first_time, last_time))
+            log.debug('Not in track (search for:{}, start:{}, end:{})'.format(time, first_time, last_time))
             return None
 
         for point in self.points:
@@ -1903,8 +1903,8 @@ class GPXTrack:
         for attribute in 'name', 'description', 'number':
             value = getattr(self, attribute)
             if value is not None:
-                representation += '%s%s=%s' % (', ' if representation else '', attribute, repr(value))
-        representation += '%ssegments=%s' % (', ' if representation else '', repr(self.segments))
+                representation += '{}{}={}'.format(', ' if representation else '', attribute, repr(value))
+        representation += '{}segments={}'.format(', ' if representation else '', repr(self.segments))
         return 'GPXTrack(%s)' % representation
 
 
@@ -2706,7 +2706,7 @@ class GPX:
 
         version_path = version.replace('.', '/')
 
-        self.nsmap['defaultns'] = 'http://www.topografix.com/GPX/{0}'.format(
+        self.nsmap['defaultns'] = 'http://www.topografix.com/GPX/{}'.format(
             version_path
         )
 
@@ -2756,7 +2756,7 @@ class GPX:
         for attribute in 'waypoints', 'routes', 'tracks':
             value = getattr(self, attribute)
             if value:
-                representation += '%s%s=%s' % (', ' if representation else '', attribute, repr(value))
+                representation += '{}{}={}'.format(', ' if representation else '', attribute, repr(value))
         return 'GPX(%s)' % representation
 
     def clone(self) -> "GPX":

--- a/gpxpy/gpx.py
+++ b/gpxpy/gpx.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # Copyright 2011 Tomo Krajina
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/gpxpy/gpxfield.py
+++ b/gpxpy/gpxfield.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # Copyright 2014 Tomo Krajina
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/gpxpy/gpxfield.py
+++ b/gpxpy/gpxfield.py
@@ -87,7 +87,7 @@ def parse_time(string: str) -> Optional[mod_datetime.datetime]:
             dt.append(0)
         dt.append(SimpleTZ(m.group(8))) # type: ignore
         return mod_datetime.datetime(*dt) # type: ignore
-    raise mod_gpx.GPXException('Invalid time: {0}'.format(string))
+    raise mod_gpx.GPXException('Invalid time: {}'.format(string))
 
 
 def format_time(time: mod_datetime.datetime) -> str:
@@ -194,7 +194,7 @@ class GPXField(AbstractGPXField):
         if result is None:
             if self.mandatory:
                 from . import gpx as mod_gpx
-                raise mod_gpx.GPXException('{0} is mandatory in {1} (got {2})'.format(self.name, self.tag, result))
+                raise mod_gpx.GPXException('{} is mandatory in {} (got {})'.format(self.name, self.tag, result))
             return None
 
         if self.type_converter:
@@ -202,12 +202,12 @@ class GPXField(AbstractGPXField):
                 result = self.type_converter.from_string(result)
             except Exception as e:
                 from . import gpx as mod_gpx
-                raise mod_gpx.GPXException('Invalid value for <{0}>... {1} ({2})'.format(self.tag, result, e))
+                raise mod_gpx.GPXException('Invalid value for <{}>... {} ({})'.format(self.tag, result, e))
 
         if self.possible:
             if not (result in self.possible):
                 from . import gpx as mod_gpx
-                raise mod_gpx.GPXException('Invalid value "{0}", possible: {1}'.format(result, self.possible))
+                raise mod_gpx.GPXException('Invalid value "{}", possible: {}'.format(result, self.possible))
 
         return result
 
@@ -217,7 +217,7 @@ class GPXField(AbstractGPXField):
         if not prettyprint:
             indent = ''
         if self.attribute:
-            return '{0}="{1}"'.format(self.attribute, mod_utils.make_str(value))
+            return '{}="{}"'.format(self.attribute, mod_utils.make_str(value))
         elif self.type_converter:
             value = self.type_converter.to_string(value)
         if self.tag:
@@ -289,7 +289,7 @@ class GPXEmailField(AbstractGPXField):
 
         email_id = email_node.get('id')
         email_domain = email_node.get('domain')
-        return '{0}@{1}'.format(email_id, email_domain)
+        return '{}@{}'.format(email_id, email_domain)
 
     def to_xml(self, value: Any, version: str, nsmap: Optional[Dict[str, str]]=None, prettyprint: bool=True, indent: str='') -> str:
         """
@@ -318,7 +318,7 @@ class GPXEmailField(AbstractGPXField):
             email_domain = 'unknown'
 
         return ('\n' + indent +
-                '<{0} id="{1}" domain="{2}" />'.format(self.tag,
+                '<{} id="{}" domain="{}" />'.format(self.tag,
                                                        email_id, email_domain))
 
 
@@ -403,7 +403,7 @@ class GPXExtensionsField(AbstractGPXField):
         result.append('\n' + indent + '<' + prefixedname)
         for attrib, value in node.attrib.items():
             attrib = self._resolve_prefix(attrib, nsmap)
-            result.append(' {0}="{1}"'.format(attrib, value))
+            result.append(' {}="{}"'.format(attrib, value))
         result.append('>')
         if node.text is not None:
              result.append(node.text.strip())
@@ -503,17 +503,17 @@ def gpx_fields_to_xml(instance: Any, tag: str, version: str, custom_attributes: 
     if tag:
         body.append('\n' + indent + '<' + tag)
         if tag == 'gpx':  # write nsmap in root node
-            body.append(' xmlns="{0}"'.format(nsmap['defaultns']))
+            body.append(' xmlns="{}"'.format(nsmap['defaultns']))
             namespaces = set(nsmap.keys())
             namespaces.remove('defaultns')
             for prefix in sorted(namespaces):
                 body.append(
-                    ' xmlns:{0}="{1}"'.format(prefix, nsmap[prefix])
+                    ' xmlns:{}="{}"'.format(prefix, nsmap[prefix])
                 )
         if custom_attributes:
             # Make sure to_xml() always return attributes in the same order:
             for key in sorted(custom_attributes.keys()):
-                body.append(' {0}="{1}"'.format(key, mod_utils.make_str(custom_attributes[key])))
+                body.append(' {}="{}"'.format(key, mod_utils.make_str(custom_attributes[key])))
     suppressuntil = ''
     for gpx_field in fields:
         # strings indicate non-data container tags with subelements
@@ -530,13 +530,13 @@ def gpx_fields_to_xml(instance: Any, tag: str, version: str, custom_attributes: 
                         body.append('>')
                         tag_open = False
                     if gpx_field[0] == '/':
-                        body.append('\n' + indent + '<{0}>'.format(gpx_field))
+                        body.append('\n' + indent + '<{}>'.format(gpx_field))
                         if prettyprint and len(indent) > 1:
                             indent = indent[:-2]
                     else:
                         if prettyprint:
                             indent += '  '
-                        body.append('\n' + indent + '<{0}'.format(gpx_field))
+                        body.append('\n' + indent + '<{}'.format(gpx_field))
                         tag_open = True
         elif not suppressuntil:
             value = getattr(instance, gpx_field.name)
@@ -609,14 +609,14 @@ def gpx_check_slots_and_default_values(classs: Callable[[], Any]) -> None:
         attributes = list(filter(lambda x : not callable(getattr(instance, x)), attributes))
         attributes = list(filter(lambda x : not x.startswith('gpx_'), attributes))
     except Exception as e:
-        raise Exception('Error reading attributes for %s: %s' % (classs.__name__, e))
+        raise Exception('Error reading attributes for {}: {}'.format(classs.__name__, e))
 
     attributes.sort()
     slots = list(classs.__slots__)
     slots.sort()
 
     if attributes != slots:
-        raise Exception('Attributes for %s is\n%s but should be\n%s' % (classs.__name__, attributes, slots))
+        raise Exception('Attributes for {} is\n{} but should be\n{}'.format(classs.__name__, attributes, slots))
 
     for field in fields:
         if not isinstance(field, str):
@@ -626,7 +626,7 @@ def gpx_check_slots_and_default_values(classs: Callable[[], Any]) -> None:
             try:
                 actual_value = getattr(instance, field.name)
             except:
-                raise Exception('%s has no attribute %s' % (classs.__name__, field.name))
+                raise Exception('{} has no attribute {}'.format(classs.__name__, field.name))
             if field.name != "latitude" and field.name != "longitude" and value != actual_value:
                 raise Exception('Invalid default value %s.%s is %s but should be %s'
                                 % (classs.__name__, field.name, actual_value, value))

--- a/gpxpy/gpxfield.py
+++ b/gpxpy/gpxfield.py
@@ -85,7 +85,7 @@ def parse_time(string: str) -> Optional[mod_datetime.datetime]:
             dt.append(0)
         dt.append(SimpleTZ(m.group(8))) # type: ignore
         return mod_datetime.datetime(*dt) # type: ignore
-    raise mod_gpx.GPXException('Invalid time: {}'.format(string))
+    raise mod_gpx.GPXException(f'Invalid time: {string}')
 
 
 def format_time(time: mod_datetime.datetime) -> str:
@@ -192,7 +192,7 @@ class GPXField(AbstractGPXField):
         if result is None:
             if self.mandatory:
                 from . import gpx as mod_gpx
-                raise mod_gpx.GPXException('{} is mandatory in {} (got {})'.format(self.name, self.tag, result))
+                raise mod_gpx.GPXException(f'{self.name} is mandatory in {self.tag} (got {result})')
             return None
 
         if self.type_converter:
@@ -200,12 +200,12 @@ class GPXField(AbstractGPXField):
                 result = self.type_converter.from_string(result)
             except Exception as e:
                 from . import gpx as mod_gpx
-                raise mod_gpx.GPXException('Invalid value for <{}>... {} ({})'.format(self.tag, result, e))
+                raise mod_gpx.GPXException(f'Invalid value for <{self.tag}>... {result} ({e})')
 
         if self.possible:
             if not (result in self.possible):
                 from . import gpx as mod_gpx
-                raise mod_gpx.GPXException('Invalid value "{}", possible: {}'.format(result, self.possible))
+                raise mod_gpx.GPXException(f'Invalid value "{result}", possible: {self.possible}')
 
         return result
 
@@ -287,7 +287,7 @@ class GPXEmailField(AbstractGPXField):
 
         email_id = email_node.get('id')
         email_domain = email_node.get('domain')
-        return '{}@{}'.format(email_id, email_domain)
+        return f'{email_id}@{email_domain}'
 
     def to_xml(self, value: Any, version: str, nsmap: Optional[Dict[str, str]]=None, prettyprint: bool=True, indent: str='') -> str:
         """
@@ -401,7 +401,7 @@ class GPXExtensionsField(AbstractGPXField):
         result.append('\n' + indent + '<' + prefixedname)
         for attrib, value in node.attrib.items():
             attrib = self._resolve_prefix(attrib, nsmap)
-            result.append(' {}="{}"'.format(attrib, value))
+            result.append(f' {attrib}="{value}"')
         result.append('>')
         if node.text is not None:
              result.append(node.text.strip())
@@ -528,13 +528,13 @@ def gpx_fields_to_xml(instance: Any, tag: str, version: str, custom_attributes: 
                         body.append('>')
                         tag_open = False
                     if gpx_field[0] == '/':
-                        body.append('\n' + indent + '<{}>'.format(gpx_field))
+                        body.append('\n' + indent + f'<{gpx_field}>')
                         if prettyprint and len(indent) > 1:
                             indent = indent[:-2]
                     else:
                         if prettyprint:
                             indent += '  '
-                        body.append('\n' + indent + '<{}'.format(gpx_field))
+                        body.append('\n' + indent + f'<{gpx_field}')
                         tag_open = True
         elif not suppressuntil:
             value = getattr(instance, gpx_field.name)
@@ -607,14 +607,14 @@ def gpx_check_slots_and_default_values(classs: Callable[[], Any]) -> None:
         attributes = list(filter(lambda x : not callable(getattr(instance, x)), attributes))
         attributes = list(filter(lambda x : not x.startswith('gpx_'), attributes))
     except Exception as e:
-        raise Exception('Error reading attributes for {}: {}'.format(classs.__name__, e))
+        raise Exception(f'Error reading attributes for {classs.__name__}: {e}')
 
     attributes.sort()
     slots = list(classs.__slots__)
     slots.sort()
 
     if attributes != slots:
-        raise Exception('Attributes for {} is\n{} but should be\n{}'.format(classs.__name__, attributes, slots))
+        raise Exception(f'Attributes for {classs.__name__} is\n{attributes} but should be\n{slots}')
 
     for field in fields:
         if not isinstance(field, str):
@@ -624,7 +624,7 @@ def gpx_check_slots_and_default_values(classs: Callable[[], Any]) -> None:
             try:
                 actual_value = getattr(instance, field.name)
             except:
-                raise Exception('{} has no attribute {}'.format(classs.__name__, field.name))
+                raise Exception(f'{classs.__name__} has no attribute {field.name}')
             if field.name != "latitude" and field.name != "longitude" and value != actual_value:
                 raise Exception('Invalid default value %s.%s is %s but should be %s'
                                 % (classs.__name__, field.name, actual_value, value))

--- a/gpxpy/gpxxml.py
+++ b/gpxpy/gpxxml.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 import xml.dom.minidom as mod_minidom # type: ignore
 
 from typing import Any, AnyStr, Iterable

--- a/gpxpy/parser.py
+++ b/gpxpy/parser.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # Copyright 2011 Tomo Krajina
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/gpxpy/utils.py
+++ b/gpxpy/utils.py
@@ -24,7 +24,7 @@ def to_xml(tag: str, attributes: Any=None, content: Any=None, default: Any=None,
         indent = ''
     attributes = attributes or {}
     result: List[str] = []
-    result.append('\n' + indent + '<{}'.format(tag))
+    result.append('\n' + indent + f'<{tag}')
 
     if content is None and default:
         content = default
@@ -39,7 +39,7 @@ def to_xml(tag: str, attributes: Any=None, content: Any=None, default: Any=None,
         if escape:
             result.append(make_str('>{}</{}>'.format(mod_saxutils.escape(content), tag)))
         else:
-            result.append(make_str('>{}</{}>'.format(content, tag)))
+            result.append(make_str(f'>{content}</{tag}>'))
 
     return make_str(''.join(result))
 

--- a/gpxpy/utils.py
+++ b/gpxpy/utils.py
@@ -26,22 +26,22 @@ def to_xml(tag: str, attributes: Any=None, content: Any=None, default: Any=None,
         indent = ''
     attributes = attributes or {}
     result: List[str] = []
-    result.append('\n' + indent + '<{0}'.format(tag))
+    result.append('\n' + indent + '<{}'.format(tag))
 
     if content is None and default:
         content = default
 
     if attributes:
         for attribute in attributes.keys():
-            result.append(make_str(' %s="%s"' % (attribute, attributes[attribute])))
+            result.append(make_str(' {}="{}"'.format(attribute, attributes[attribute])))
 
     if content is None:
         result.append('/>')
     else:
         if escape:
-            result.append(make_str('>%s</%s>' % (mod_saxutils.escape(content), tag)))
+            result.append(make_str('>{}</{}>'.format(mod_saxutils.escape(content), tag)))
         else:
-            result.append(make_str('>%s</%s>' % (content, tag)))
+            result.append(make_str('>{}</{}>'.format(content, tag)))
 
     return make_str(''.join(result))
 

--- a/gpxpy/utils.py
+++ b/gpxpy/utils.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # Copyright 2011 Tomo Krajina
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ setup(
     author_email='tkrajina@gmail.com',
     url='http://www.trackprofiler.com/gpxpy/index.html',
     packages=['gpxpy', ],
-    python_requires=">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*",
+    python_requires=">=3.6",
     classifiers=[
         "Programming Language :: Python",
         "Programming Language :: Python :: 3.6",

--- a/test.py
+++ b/test.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # Copyright 2011 Tomo Krajina
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -25,7 +23,6 @@ Run single test with:
     $ python -m unittest test.GPXTests.test_method
 """
 
-from __future__ import print_function
 
 import logging as mod_logging
 import os as mod_os

--- a/test.py
+++ b/test.py
@@ -94,11 +94,11 @@ def equals(object1: Any, object2: Any, ignore: Any=None) -> bool:
         if not attr1 and not attr2:
             return True
         if not attr1 or not attr2:
-            print('Object differs in attribute %s (%s - %s)' % (attr, attr1, attr2))
+            print('Object differs in attribute {} ({} - {})'.format(attr, attr1, attr2))
             return False
 
         if not equals(attr1, attr2):
-            print('Object differs in attribute %s (%s - %s)' % (attr, attr1, attr2))
+            print('Object differs in attribute {} ({} - {})'.format(attr, attr1, attr2))
             return False
 
     return True
@@ -127,7 +127,7 @@ def get_dom_node(dom: Any, path: str) -> Any:
         try:
             result = candidates[n]
         except Exception:
-            raise Exception('Can\'t fint %sth child of %s' % (n, path_part))
+            raise Exception('Can\'t fint {}th child of {}'.format(n, path_part))
 
     return result
 
@@ -152,11 +152,11 @@ def elements_equal(e1: Any, e2: Any) -> bool:
     return all(elements_equal(c1, c2) for c1, c2 in zip(e1, e2))
 
 def print_etree(e1: Any, indent: str='') -> str:
-    tag = ['{0}tag: |{1}|\n'.format(indent,e1.tag)]
+    tag = ['{}tag: |{}|\n'.format(indent,e1.tag)]
     for att, value in e1.attrib.items():
-        tag.append('{0}-att: |{1}| = |{2}|\n'.format(indent, att, value))
-    tag.append('{0}-text: |{1}|\n'.format(indent, e1.text))
-    tag.append('{0}-tail: |{1}|\n'.format(indent, e1.tail))
+        tag.append('{}-att: |{}| = |{}|\n'.format(indent, att, value))
+    tag.append('{}-text: |{}|\n'.format(indent, e1.text))
+    tag.append('{}-tail: |{}|\n'.format(indent, e1.tail))
     for subelem in e1:
         tag.append(print_etree(subelem, indent+'__|'))
     return ''.join(tag)
@@ -537,8 +537,8 @@ class GPXTests(mod_unittest.TestCase):
         moving_time, stopped_time, moving_distance, stopped_distance, max_speed = gpx.get_moving_data(stopped_speed_threshold=0.1)
         print('-----')
         print('Length: %s' % length)
-        print('Moving time: %s (%smin)' % (moving_time, moving_time / 60.))
-        print('Stopped time: %s (%smin)' % (stopped_time, stopped_time / 60.))
+        print('Moving time: {} ({}min)'.format(moving_time, moving_time / 60.))
+        print('Stopped time: {} ({}min)'.format(stopped_time, stopped_time / 60.))
         print('Moving distance: %s' % moving_distance)
         print('Stopped distance: %s' % stopped_distance)
         print('Max speed: %sm/s' % max_speed)

--- a/test.py
+++ b/test.py
@@ -91,11 +91,11 @@ def equals(object1: Any, object2: Any, ignore: Any=None) -> bool:
         if not attr1 and not attr2:
             return True
         if not attr1 or not attr2:
-            print('Object differs in attribute {} ({} - {})'.format(attr, attr1, attr2))
+            print(f'Object differs in attribute {attr} ({attr1} - {attr2})')
             return False
 
         if not equals(attr1, attr2):
-            print('Object differs in attribute {} ({} - {})'.format(attr, attr1, attr2))
+            print(f'Object differs in attribute {attr} ({attr1} - {attr2})')
             return False
 
     return True
@@ -124,7 +124,7 @@ def get_dom_node(dom: Any, path: str) -> Any:
         try:
             result = candidates[n]
         except Exception:
-            raise Exception('Can\'t fint {}th child of {}'.format(n, path_part))
+            raise Exception(f'Can\'t fint {n}th child of {path_part}')
 
     return result
 
@@ -149,11 +149,11 @@ def elements_equal(e1: Any, e2: Any) -> bool:
     return all(elements_equal(c1, c2) for c1, c2 in zip(e1, e2))
 
 def print_etree(e1: Any, indent: str='') -> str:
-    tag = ['{}tag: |{}|\n'.format(indent,e1.tag)]
+    tag = [f'{indent}tag: |{e1.tag}|\n']
     for att, value in e1.attrib.items():
-        tag.append('{}-att: |{}| = |{}|\n'.format(indent, att, value))
-    tag.append('{}-text: |{}|\n'.format(indent, e1.text))
-    tag.append('{}-tail: |{}|\n'.format(indent, e1.tail))
+        tag.append(f'{indent}-att: |{att}| = |{value}|\n')
+    tag.append(f'{indent}-text: |{e1.text}|\n')
+    tag.append(f'{indent}-tail: |{e1.tail}|\n')
     for subelem in e1:
         tag.append(print_etree(subelem, indent+'__|'))
     return ''.join(tag)

--- a/xsd/pretty_print_schemas.py
+++ b/xsd/pretty_print_schemas.py
@@ -28,7 +28,7 @@ def parse_1_1_element_node(gpx_element_node: Any, complex_type_nodes: Dict[str, 
     result = ''
     node_type = gpx_element_node.attributes['type'].value
     node_name = gpx_element_node.attributes['name'].value
-    result += get_indented(depth, '%s (%s)' % (node_name, node_type))
+    result += get_indented(depth, '{} ({})'.format(node_name, node_type))
     if node_type in complex_type_nodes:
         # Complex node => parse:
         attribute_nodes = get_children_by_tag_name(complex_type_nodes[node_type], 'xsd:attribute')
@@ -36,7 +36,7 @@ def parse_1_1_element_node(gpx_element_node: Any, complex_type_nodes: Dict[str, 
             attribute_node_name = attribute_node.attributes['name'].value
             attribute_node_type = attribute_node.attributes['type'].value
             attribute_node_required = attribute_node.attributes['required'].value if attribute_node.attributes.has_key('required') else None
-            result += get_indented(depth + 1, '- attr: %s (%s) %s' % (attribute_node_name, attribute_node_type, attribute_node_required))
+            result += get_indented(depth + 1, '- attr: {} ({}) {}'.format(attribute_node_name, attribute_node_type, attribute_node_required))
         sequence_nodes = get_children_by_tag_name(complex_type_nodes[node_type], 'xsd:sequence')
         if len(sequence_nodes) > 0:
             sequence_node = sequence_nodes[0]
@@ -75,7 +75,7 @@ def parse_1_0_elements(element: Any, depth: int=0) -> Any:
             attribute_node_name = attribute_node.attributes['name'].value
             attribute_node_type = attribute_node.attributes['type'].value
             attribute_node_use = attribute_node.attributes['use'].value if attribute_node.attributes.has_key('use') else None
-            result += get_indented(depth + 1, '- attr: %s (%s) %s' % (attribute_node_name, attribute_node_type, attribute_node_use))
+            result += get_indented(depth + 1, '- attr: {} ({}) {}'.format(attribute_node_name, attribute_node_type, attribute_node_use))
         sequences = get_children_by_tag_name(complex_type, 'xsd:sequence')
         if len(sequences) > 0:
             sequence = sequences[0]

--- a/xsd/pretty_print_schemas.py
+++ b/xsd/pretty_print_schemas.py
@@ -28,7 +28,7 @@ def parse_1_1_element_node(gpx_element_node: Any, complex_type_nodes: Dict[str, 
     result = ''
     node_type = gpx_element_node.attributes['type'].value
     node_name = gpx_element_node.attributes['name'].value
-    result += get_indented(depth, '{} ({})'.format(node_name, node_type))
+    result += get_indented(depth, f'{node_name} ({node_type})')
     if node_type in complex_type_nodes:
         # Complex node => parse:
         attribute_nodes = get_children_by_tag_name(complex_type_nodes[node_type], 'xsd:attribute')
@@ -36,7 +36,7 @@ def parse_1_1_element_node(gpx_element_node: Any, complex_type_nodes: Dict[str, 
             attribute_node_name = attribute_node.attributes['name'].value
             attribute_node_type = attribute_node.attributes['type'].value
             attribute_node_required = attribute_node.attributes['required'].value if attribute_node.attributes.has_key('required') else None
-            result += get_indented(depth + 1, '- attr: {} ({}) {}'.format(attribute_node_name, attribute_node_type, attribute_node_required))
+            result += get_indented(depth + 1, f'- attr: {attribute_node_name} ({attribute_node_type}) {attribute_node_required}')
         sequence_nodes = get_children_by_tag_name(complex_type_nodes[node_type], 'xsd:sequence')
         if len(sequence_nodes) > 0:
             sequence_node = sequence_nodes[0]
@@ -75,7 +75,7 @@ def parse_1_0_elements(element: Any, depth: int=0) -> Any:
             attribute_node_name = attribute_node.attributes['name'].value
             attribute_node_type = attribute_node.attributes['type'].value
             attribute_node_use = attribute_node.attributes['use'].value if attribute_node.attributes.has_key('use') else None
-            result += get_indented(depth + 1, '- attr: {} ({}) {}'.format(attribute_node_name, attribute_node_type, attribute_node_use))
+            result += get_indented(depth + 1, f'- attr: {attribute_node_name} ({attribute_node_type}) {attribute_node_use}')
         sequences = get_children_by_tag_name(complex_type, 'xsd:sequence')
         if len(sequences) > 0:
             sequence = sequences[0]


### PR DESCRIPTION
Update `python_requires` to tell pip to only install on Python 3.6+.

Also upgrade Python syntax using https://github.com/asottile/pyupgrade, to take advantage of features of Python 3.6.