### PR TITLE
bugfix and simpler code

### DIFF
--- a/gpxpy/gpx.py
+++ b/gpxpy/gpx.py
@@ -781,7 +781,7 @@ class GPXTrackSegment:
         for track_point in self.points:
             track_point.move(location_delta)
 
-    def walk(self, only_points: bool=False) -> Iterator[Union[GPXTrackPoint, Tuple[GPXTrackPoint, int]]]:
+    def walk(self, only_points: bool=False) -> Iterator[Any]: # Union[GPXTrackPoint, Tuple[GPXTrackPoint, int]]]:
         """
         Generator for iterating over segment points
 
@@ -1545,7 +1545,7 @@ class GPXTrack:
 
         return bounds
 
-    def walk(self, only_points: bool=False) -> Iterator[Union[GPXTrackPoint, Tuple[GPXTrackPoint, int, int]]]:
+    def walk(self, only_points: bool=False) -> Iterator[Any]: #Union[GPXTrackPoint, Tuple[GPXTrackPoint, int, int]]]:
         """
         Generator used to iterates through track
 

--- a/gpxpy/gpx.py
+++ b/gpxpy/gpx.py
@@ -1214,6 +1214,13 @@ class GPXTrackSegment:
         
         return None
 
+    def get_nearest_location_x(self, location: mod_geo.Location) -> Optional[NearestLocationData]:
+        """ Return the (location, track_point_no) on this track segment """
+        if (self.points is None) or len(self.points) == 0:
+            return None
+        result_track_point_no,result = min(enumerate(self.points), key=lambda x: x[1].distance_2d(location))
+        return NearestLocationData(result, -1, -1, result_track_point_no)
+        
     def get_nearest_location(self, location: mod_geo.Location) -> Optional[NearestLocationData]:
         """ Return the (location, track_point_no) on this track segment """
         if not self.points:
@@ -1228,8 +1235,13 @@ class GPXTrackSegment:
                 result = track_point
             else:
                 distance = track_point.distance_2d(location)
-                #print current_distance, distance
-                if not current_distance or distance < current_distance:
+                #if (current_distance == None) or distance < current_distance:
+                # if not ( (not current_distance or distance < current_distance) == ((current_distance == None) or distance < current_distance ) ):
+                #     print(';xx;', not current_distance or distance < current_distance, (current_distance == None) or distance < current_distance )
+                #     print(';xx;', (not current_distance) or distance < current_distance, (current_distance == None) or distance < current_distance )
+                #if not current_distance or distance < current_distance:
+                if (current_distance is None) or distance < current_distance:
+                    #print ("huhu",current_distance, distance)
                     current_distance = distance
                     result = track_point
                     result_track_point_no = i

--- a/gpxpy/gpx.py
+++ b/gpxpy/gpx.py
@@ -1214,41 +1214,12 @@ class GPXTrackSegment:
         
         return None
 
-    def get_nearest_location_x(self, location: mod_geo.Location) -> Optional[NearestLocationData]:
+    def get_nearest_location(self, location: mod_geo.Location) -> Optional[NearestLocationData]:
         """ Return the (location, track_point_no) on this track segment """
         if (self.points is None) or len(self.points) == 0:
             return None
         result_track_point_no,result = min(enumerate(self.points), key=lambda x: x[1].distance_2d(location))
         return NearestLocationData(result, -1, -1, result_track_point_no)
-        
-    def get_nearest_location(self, location: mod_geo.Location) -> Optional[NearestLocationData]:
-        """ Return the (location, track_point_no) on this track segment """
-        if not self.points:
-            return None
-
-        result: Optional[GPXTrackPoint] = None
-        current_distance = None
-        result_track_point_no = None
-        for i in range(len(self.points)):
-            track_point = self.points[i]
-            if not result:
-                result = track_point
-            else:
-                distance = track_point.distance_2d(location)
-                #if (current_distance == None) or distance < current_distance:
-                # if not ( (not current_distance or distance < current_distance) == ((current_distance == None) or distance < current_distance ) ):
-                #     print(';xx;', not current_distance or distance < current_distance, (current_distance == None) or distance < current_distance )
-                #     print(';xx;', (not current_distance) or distance < current_distance, (current_distance == None) or distance < current_distance )
-                #if not current_distance or distance < current_distance:
-                if (current_distance is None) or distance < current_distance:
-                    #print ("huhu",current_distance, distance)
-                    current_distance = distance
-                    result = track_point
-                    result_track_point_no = i
-
-        if result is not None and result_track_point_no is not None:
-            return NearestLocationData(result, -1, -1, result_track_point_no)
-        return None
 
     def smooth(self, vertical: bool=True, horizontal: bool=False, remove_extremes: bool=False) -> None:
         """ "Smooths" the elevation graph. Can be called multiple times. """

--- a/test.py
+++ b/test.py
@@ -135,7 +135,7 @@ def get_dom_node(dom: Any, path: str) -> Any:
 ##    input()
 
 
-def node_strip(text: AnyStr) -> AnyStr:
+def node_strip(text: str) -> str:
     if text is None:
         return ''
     return text.strip()

--- a/test.py
+++ b/test.py
@@ -393,26 +393,39 @@ class GPXTests(mod_unittest.TestCase):
 ##        self.assertTrue(make_str(security) == 'Open')
 
     def test_nearest_location_1(self) -> None:
+        def test_nearest_location_gpx(gpx) -> None:
+            location = mod_geo.Location(45.451058791, 14.027903696)
+            nearest_loc_info = gpx.get_nearest_location(location)
+            print(nearest_loc_info)
+            if gpx.tracks is not None:
+                self.assertTrue(nearest_loc_info is not None)
+                point = gpx.tracks[nearest_loc_info.track_no].segments[nearest_loc_info.segment_no].points[nearest_loc_info.point_no] # type: ignore
+                self.assertTrue(point.distance_2d(location) < 0.001) # type: ignore
+                self.assertTrue(point.distance_2d(nearest_loc_info.location) < 0.001) # type: ignore
+
+                nearest_nearest_loc_info =  gpx.get_nearest_location(point)
+                self.assertTrue( nearest_nearest_loc_info == nearest_loc_info ) # type: ignore
+            
+                location = mod_geo.Location(1, 1)
+                nearest_location, track_no, track_segment_no, track_point_no = gpx.get_nearest_location(location) # type: ignore
+                point = gpx.tracks[track_no].segments[track_segment_no].points[track_point_no]
+                self.assertTrue(point.distance_2d(nearest_location) < 0.001) # type: ignore
+
+                location = mod_geo.Location(50, 50)
+                nearest_location, track_no, track_segment_no, track_point_no = gpx.get_nearest_location(location) # type: ignore
+                point = gpx.tracks[track_no].segments[track_segment_no].points[track_point_no]
+                self.assertTrue(point.distance_2d(nearest_location) < 0.001) # type: ignore
+                
         gpx = self.parse('korita-zbevnica.gpx')
-
-        location = mod_geo.Location(45.451058791, 14.027903696)
-        nearest_loc_info = gpx.get_nearest_location(location)
-        print(nearest_loc_info)
-        self.assertTrue(nearest_loc_info is not None)
-        point = gpx.tracks[nearest_loc_info.track_no].segments[nearest_loc_info.segment_no].points[nearest_loc_info.point_no] # type: ignore
-        self.assertTrue(point.distance_2d(location) < 0.001) # type: ignore
-        self.assertTrue(point.distance_2d(nearest_loc_info.location) < 0.001) # type: ignore
-
-        location = mod_geo.Location(1, 1)
-        nearest_location, track_no, track_segment_no, track_point_no = gpx.get_nearest_location(location) # type: ignore
-        point = gpx.tracks[track_no].segments[track_segment_no].points[track_point_no]
-        self.assertTrue(point.distance_2d(nearest_location) < 0.001) # type: ignore
-
-        location = mod_geo.Location(50, 50)
-        nearest_location, track_no, track_segment_no, track_point_no = gpx.get_nearest_location(location) # type: ignore
-        point = gpx.tracks[track_no].segments[track_segment_no].points[track_point_no]
-        self.assertTrue(point.distance_2d(nearest_location) < 0.001) # type: ignore
-
+        test_nearest_location_gpx(gpx)
+        gpx.tracks[0].segments[0].points=None
+        test_nearest_location_gpx(gpx)
+        gpx.tracks[0].segments=None
+        test_nearest_location_gpx(gpx)
+        gpx.tracks=None
+        test_nearest_location_gpx(gpx)
+        
+        
     def test_long_timestamps(self) -> None:
         # Check if timestamps in format: 1901-12-13T20:45:52.2073437Z work
         gpx = self.parse('Mojstrovka.gpx')


### PR DESCRIPTION
The original code of get_nearest_location(location) has the property that if 'location' is a point on the track, the point after 'location' on the track is returned (for that case 'not distance' is True because distance is 0.0).
There is a version that only adjusts for this behavior in the middle commit. 
I consider the version using min(..,key=lambda ..) even more readable.

One could consider this a hotfix, so perhaps it should be a pull request on master.  If you prefer this, I can prepare such a pull request. (I'll have to do it from a different fork because this one has the full merge of dev...)