### PR TITLE
Modernize code to Python 3.6+

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,15 +27,15 @@ gpx = gpxpy.parse(gpx_file)
 for track in gpx.tracks:
     for segment in track.segments:
         for point in segment.points:
-            print('Point at ({0},{1}) -> {2}'.format(point.latitude, point.longitude, point.elevation))
+            print(f'Point at ({point.latitude},{point.longitude}) -> {point.elevation}')
 
 for waypoint in gpx.waypoints:
-    print('waypoint {0} -> ({1},{2})'.format(waypoint.name, waypoint.latitude, waypoint.longitude))
+    print(f'waypoint {waypoint.name} -> ({waypoint.latitude},{waypoint.longitude})')
 
 for route in gpx.routes:
     print('Route:')
     for point in route.points:
-        print('Point at ({0},{1}) -> {2}'.format(point.latitude, point.longitude, point.elevation))
+        print(f'Point at ({point.latitude},{point.longitude}) -> {point.elevtion}')
 
 # There are many more utility methods and functions:
 # You can manipulate/add/remove tracks, segments, points, waypoints and routes and

--- a/examples/extension_write_example.py
+++ b/examples/extension_write_example.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3
-# -*- coding: utf-8 -*-
 
 """
 Example File for gpxpy waypoints

--- a/examples/extension_write_example.py
+++ b/examples/extension_write_example.py
@@ -26,12 +26,12 @@ gpx.description = 'Marrekrite aanlegplaatsen'
 namespace = '{opencpn}'
 
 #create extension element
-root = mod_etree.Element(namespace + 'scale_min_max')
-#mod_etree.SubElement(root, namespace + 'UseScale')
+root = mod_etree.Element(f'{namespace}scale_min_max')
+#mod_etree.SubElement(root, f'{namespace}UseScale')
 root.attrib['UseScale'] = "true"
 root.attrib['ScaleMin'] = "50000"
 root.attrib['ScaleMax'] = "0"
-rootElement2 = mod_etree.Element(namespace + 'arrival_radius')
+rootElement2 = mod_etree.Element(f'{namespace}arrival_radius')
 rootElement2.text = '0.050'
 
 #add extension to header

--- a/examples/waypoints_example.py
+++ b/examples/waypoints_example.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3
-# -*- coding: utf-8 -*-
 
 """
 Example File for gpxpy waypoints

--- a/gpxinfo
+++ b/gpxinfo
@@ -26,32 +26,32 @@ def format_time(time_s: float) -> str:
     elif args.seconds:
         return str(int(time_s))
     else:
-        minutes = mod_math.floor(time_s / 60.)
-        hours = mod_math.floor(minutes / 60.)
-        return '%s:%s:%s' % (str(int(hours)).zfill(2), str(int(minutes % 60)).zfill(2), str(int(time_s % 60)).zfill(2))
+        mins, secs = divmod(int(time_s), 60)
+        hrs, mins = divmod(mins, 60)
+        return f"{hrs:02d}:{mins:02d}:{secs:02d}"
 
 
 def format_long_length(length: float) -> str:
     if args.miles:
-        return '{:.3f}miles'.format(length / 1000. * KM_TO_MILES)
+        return f'{length / 1000. * KM_TO_MILES:.3f}miles'
     else:
-        return '{:.3f}km'.format(length / 1000.)
+        return f'{length / 1000.:.3f}km'
 
 
 def format_short_length(length: float) -> str:
     if args.miles:
-        return '{:.2f}ft'.format(length * M_TO_FEET)
+        return f'{length * M_TO_FEET:.2f}ft'
     else:
-        return '{:.2f}m'.format(length)
+        return f'{length:.2f}m'
 
 
 def format_speed(speed: float) -> str:
     if not speed:
         speed = 0
     if args.miles:
-        return '{:.2f}mph'.format(speed * KM_TO_MILES * 3600. / 1000.)
+        return f'{speed * KM_TO_MILES * 3600. / 1000.:.2f}mph'
     else:
-        return '{:.2f}m/s = {:.2f}km/h'.format(speed, speed * 3600. / 1000.)
+        return f'{speed:.2f}m/s = {speed * 3600. / 1000.:.2f}km/h'
 
 
 def print_gpx_part_info(gpx_part: Union[mod_gpx.GPX, mod_gpx.GPXTrack, mod_gpx.GPXTrackSegment], indentation: str='    ') -> None:
@@ -60,8 +60,8 @@ def print_gpx_part_info(gpx_part: Union[mod_gpx.GPX, mod_gpx.GPXTrack, mod_gpx.G
     """
     length_2d = gpx_part.length_2d()
     length_3d = gpx_part.length_3d()
-    print('%sLength 2D: %s' % (indentation, format_long_length(length_2d or 0)))
-    print('%sLength 3D: %s' % (indentation, format_long_length(length_3d)))
+    print(f'{indentation}Length 2D: {format_long_length(length_2d or 0)}')
+    print(f'{indentation}Length 3D: {format_long_length(length_3d)}')
 
     moving_data = gpx_part.get_moving_data()
     raw_moving_data = gpx_part.get_moving_data(raw=True)
@@ -72,15 +72,15 @@ def print_gpx_part_info(gpx_part: Union[mod_gpx.GPX, mod_gpx.GPXTrack, mod_gpx.G
         print(f'{indentation}Avg speed: {format_speed(moving_data.moving_distance / moving_data.moving_time) if moving_data.moving_time > 0 else "?"}')
 
     uphill, downhill = gpx_part.get_uphill_downhill()
-    print('%sTotal uphill: %s' % (indentation, format_short_length(uphill)))
-    print('%sTotal downhill: %s' % (indentation, format_short_length(downhill)))
+    print(f'{indentation}Total uphill: {format_short_length(uphill)}')
+    print(f'{indentation}Total downhill: {format_short_length(downhill)}')
 
     start_time, end_time = gpx_part.get_time_bounds()
-    print('%sStarted: %s' % (indentation, start_time))
-    print('%sEnded: %s' % (indentation, end_time))
+    print(f'{indentation}Started: {start_time}')
+    print(f'{indentation}Ended: {end_time}')
 
     points_no = len(list(gpx_part.walk(only_points=True)))
-    print('%sPoints: %s' % (indentation, points_no))
+    print(f'{indentation}Points: {points_no}')
 
     if points_no > 0:
         distances: List[float] = []
@@ -90,28 +90,28 @@ def print_gpx_part_info(gpx_part: Union[mod_gpx.GPX, mod_gpx.GPXTrack, mod_gpx.G
                 distance = point.distance_2d(previous_point)
                 distances.append(distance)
             previous_point = point
-        print('%sAvg distance between points: %s' % (indentation, format_short_length(sum(distances) / len(list(gpx_part.walk())))))
+        print(f'{indentation}Avg distance between points: {format_short_length(sum(distances) / len(list(gpx_part.walk())))}')
 
     print('')
 
 
 def print_gpx_info(gpx: mod_gpx.GPX, gpx_file: str) -> None:
-    print('File: %s' % gpx_file)
+    print(f'File: {gpx_file}')
 
     if gpx.name:
-        print('  GPX name: %s' % gpx.name)
+        print(f'  GPX name: {gpx.name}')
     if gpx.description:
-        print('  GPX description: %s' % gpx.description)
+        print(f'  GPX description: {gpx.description}')
     if gpx.author_name:
-        print('  Author: %s' % gpx.author_name)
+        print(f'  Author: {gpx.author_name}')
     if gpx.author_email:
-        print('  Email: %s' % gpx.author_email)
+        print(f'  Email: {gpx.author_email}')
 
     print_gpx_part_info(gpx)
 
     for track_no, track in enumerate(gpx.tracks):
         for segment_no, segment in enumerate(track.segments):
-            print('    Track #%s, Segment #%s' % (track_no, segment_no))
+            print(f'    Track #{track_no}, Segment #{segment_no}')
             print_gpx_part_info(segment, indentation='        ')
 
 
@@ -126,7 +126,7 @@ def run(gpx_files: List[str]) -> None:
             print_gpx_info(gpx, gpx_file)
         except Exception as e:
             mod_logging.exception(e)
-            print('Error processing %s' % gpx_file)
+            print(f'Error processing {gpx_file}')
             mod_sys.exit(1)
 
 

--- a/gpxpy/gpx.py
+++ b/gpxpy/gpx.py
@@ -238,13 +238,13 @@ class GPXWaypoint(mod_geo.Location):
         return f'[wpt{{{self.name}}}:{self.latitude},{self.longitude}@{self.elevation}]'
 
     def __repr__(self) -> str:
-        representation = f'{self.latitude}, {self.longitude}'
+        parts = [f'{self.latitude}, {self.longitude}']
         for attribute in 'elevation', 'time', 'name', 'description', 'symbol', 'type', 'comment', \
                 'horizontal_dilution', 'vertical_dilution', 'position_dilution':
             value = getattr(self, attribute)
             if value is not None:
-                representation += ', {}={}'.format(attribute, repr(value))
-        return 'GPXWaypoint(%s)' % representation
+                parts.append(f'{attribute}={value!r}')
+        return f'GPXWaypoint({", ".join(parts)})'
 
     def adjust_time(self, delta: mod_datetime.timedelta) -> None:
         """
@@ -313,13 +313,13 @@ class GPXRoutePoint(mod_geo.Location):
         return f'[rtept{{{self.name}}}:{self.latitude},{self.longitude}@{self.elevation}]'
 
     def __repr__(self) -> str:
-        representation = f'{self.latitude}, {self.longitude}'
+        parts = [f'{self.latitude}, {self.longitude}']
         for attribute in 'elevation', 'time', 'name', 'description', 'symbol', 'type', 'comment', \
                 'horizontal_dilution', 'vertical_dilution', 'position_dilution':
             value = getattr(self, attribute)
             if value is not None:
-                representation += ', {}={}'.format(attribute, repr(value))
-        return 'GPXRoutePoint(%s)' % representation
+                parts.append(f'{attribute}={value!r}')
+        return f'GPXRoutePoint({", ".join(parts)})'
 
     def adjust_time(self, delta: mod_datetime.timedelta) -> None:
         """
@@ -495,13 +495,13 @@ class GPXRoute:
             route_point.move(location_delta)
 
     def __repr__(self) -> str:
-        representation = ''
+        parts = []
         for attribute in 'name', 'description', 'number':
             value = getattr(self, attribute)
             if value is not None:
-                representation += '{}{}={}'.format(', ' if representation else '', attribute, repr(value))
-        representation += '{}points=[{}])'.format(', ' if representation else '', '...' if self.points else '')
-        return 'GPXRoute(%s)' % representation
+                parts.append(f'{attribute}={value!r}')
+        parts.append(f'points=[{"..." if self.points else ""}]')
+        return f'GPXRoute({", ".join(parts)})'
 
 
 class GPXTrackPoint(mod_geo.Location):
@@ -546,13 +546,13 @@ class GPXTrackPoint(mod_geo.Location):
         self.extensions: List[Any] = []
 
     def __repr__(self) -> str:
-        representation = f'{self.latitude}, {self.longitude}'
+        parts = [f'{self.latitude}, {self.longitude}']
         for attribute in 'elevation', 'time', 'symbol', 'comment', 'horizontal_dilution', \
                 'vertical_dilution', 'position_dilution', 'speed', 'name':
             value = getattr(self, attribute)
             if value is not None:
-                representation += ', {}={}'.format(attribute, repr(value))
-        return 'GPXTrackPoint(%s)' % representation
+                parts.append(f'{attribute}={value!r}')
+        return f'GPXTrackPoint({", ".join(parts)})'
 
     def adjust_time(self, delta: mod_datetime.timedelta) -> None:
         """
@@ -1063,9 +1063,9 @@ class GPXTrackSegment:
             will be 1)
         """
         if not get_data_function:
-            raise GPXException('Invalid get_data_function: %s' % get_data_function)
+            raise GPXException(f'Invalid get_data_function: {get_data_function}')
         if not add_missing_function:
-            raise GPXException('Invalid add_missing_function: %s' % add_missing_function)
+            raise GPXException(f'Invalid add_missing_function: {add_missing_function}')
 
         # Points (*without* data) between two points (*with* data):
         interval: List[GPXTrackPoint] = []
@@ -1379,7 +1379,7 @@ class GPXTrackSegment:
 
 
     def __repr__(self) -> str:
-        return 'GPXTrackSegment(points=[%s])' % ('...' if self.points else '')
+        return f'GPXTrackSegment(points=[{"..." if self.points else ""}])'
 
     def clone(self) -> "GPXTrackSegment":
         return mod_copy.deepcopy(self)
@@ -1909,13 +1909,13 @@ class GPXTrack:
 
 
     def __repr__(self) -> str:
-        representation = ''
+        parts = []
         for attribute in 'name', 'description', 'number':
             value = getattr(self, attribute)
             if value is not None:
-                representation += '{}{}={}'.format(', ' if representation else '', attribute, repr(value))
-        representation += '{}segments={}'.format(', ' if representation else '', repr(self.segments))
-        return 'GPXTrack(%s)' % representation
+                parts.append(f'{attribute}={value!r}')
+        parts.append(f'segments={self.segments!r}')
+        return f'GPXTrack({", ".join(parts)})'
 
 
 class GPX:
@@ -2687,7 +2687,7 @@ class GPX:
                 version = '1.1'
 
         if version != '1.0' and version != '1.1':
-            raise GPXException('Invalid version %s' % version)
+            raise GPXException(f'Invalid version {version}')
 
         self.version = version
         if not self.creator:
@@ -2697,16 +2697,12 @@ class GPX:
 
         version_path = version.replace('.', '/')
 
-        self.nsmap['defaultns'] = 'http://www.topografix.com/GPX/{}'.format(
-            version_path
-        )
+        self.nsmap['defaultns'] = f'http://www.topografix.com/GPX/{version_path}'
 
         if not self.schema_locations:
             self.schema_locations = [
-                p.format(version_path) for p in (
-                    'http://www.topografix.com/GPX/{0}',
-                    'http://www.topografix.com/GPX/{0}/gpx.xsd',
-                )
+                f'http://www.topografix.com/GPX/{version_path}',
+                f'http://www.topografix.com/GPX/{version_path}/gpx.xsd',
             ]
 
         content = mod_gpxfield.gpx_fields_to_xml(
@@ -2718,7 +2714,7 @@ class GPX:
             prettyprint=prettyprint
         )
 
-        return '<?xml version="1.0" encoding="UTF-8"?>\n' + content.strip()
+        return f'<?xml version="1.0" encoding="UTF-8"?>\n{content.strip()}'
 
     def has_times(self) -> bool:
         """ See GPXTrackSegment.has_times() """
@@ -2743,12 +2739,12 @@ class GPX:
         return result
 
     def __repr__(self) -> str:
-        representation = ''
+        parts = []
         for attribute in 'waypoints', 'routes', 'tracks':
             value = getattr(self, attribute)
             if value:
-                representation += '{}{}={}'.format(', ' if representation else '', attribute, repr(value))
-        return 'GPX(%s)' % representation
+                parts.append(f'{attribute}={value!r}')
+        return f'GPX({", ".join(parts)})'
 
     def clone(self) -> "GPX":
         return mod_copy.deepcopy(self)

--- a/gpxpy/gpx.py
+++ b/gpxpy/gpx.py
@@ -1038,7 +1038,7 @@ class GPXTrackSegment:
         delta : float
             Elevation delta in meters to apply to track
         """
-        log.debug('delta = %s' % delta)
+        log.debug('delta = %s', delta)
 
         if not delta:
             return
@@ -2055,7 +2055,7 @@ class GPX:
             track.reduce_points(min_distance)
 
         # TODO
-        log.debug('Track reduced to %s points' % self.get_track_points_no())
+        log.debug('Track reduced to %s points', self.get_track_points_no())
 
     def adjust_time(self, delta: mod_datetime.timedelta, all: bool=False) -> None:
         """

--- a/gpxpy/parser.py
+++ b/gpxpy/parser.py
@@ -134,7 +134,7 @@ class GPXParser:
                 root = mod_etree.XML(self.xml)
         except Exception as e:
             # The exception here can be a lxml or ElementTree exception.
-            log.debug('Error in:\n%s\n-----------\n' % self.xml, exc_info=True)
+            log.debug('Error in:\n%s\n-----------\n', self.xml, exc_info=True)
 
             # The library should work in the same way regardless of the
             # underlying XML parser that's why the exception thrown

--- a/gpxpy/parser.py
+++ b/gpxpy/parser.py
@@ -143,7 +143,7 @@ class GPXParser:
             #
             # But, if the user needs the original exception (lxml or ElementTree)
             # it is available with GPXXMLSyntaxException.original_exception:
-            raise mod_gpx.GPXXMLSyntaxException('Error parsing XML: %s' % str(e), e)
+            raise mod_gpx.GPXXMLSyntaxException(f'Error parsing XML: {e}', e)
 
         if root is None:
             raise mod_gpx.GPXException('Document must have a `gpx` root node.')

--- a/gpxpy/utils.py
+++ b/gpxpy/utils.py
@@ -23,21 +23,20 @@ def to_xml(tag: str, attributes: Any=None, content: Any=None, default: Any=None,
     if not prettyprint:
         indent = ''
     attributes = attributes or {}
-    result: List[str] = []
-    result.append('\n' + indent + f'<{tag}')
+    result: List[str] = [f'\n{indent}<{tag}']
 
     if content is None and default:
         content = default
 
     if attributes:
         for attribute in attributes.keys():
-            result.append(make_str(' {}="{}"'.format(attribute, attributes[attribute])))
+            result.append(make_str(f' {attribute}="{attributes[attribute]}"'))
 
     if content is None:
         result.append('/>')
     else:
         if escape:
-            result.append(make_str('>{}</{}>'.format(mod_saxutils.escape(content), tag)))
+            result.append(make_str(f'>{mod_saxutils.escape(content)}</{tag}>'))
         else:
             result.append(make_str(f'>{content}</{tag}>'))
 

--- a/test.py
+++ b/test.py
@@ -165,7 +165,7 @@ class GPXTests(mod_unittest.TestCase):
     """
 
     def parse(self, file: Any, encoding: Optional[str]=None, version: Optional[str]=None) -> mod_gpx.GPX:
-        with open('test_files/%s' % file, encoding=encoding) as f:
+        with open(f'test_files/{file}', encoding=encoding) as f:
             parser = mod_parser.GPXParser(f)
             return parser.parse(version)
 
@@ -555,7 +555,7 @@ class GPXTests(mod_unittest.TestCase):
         print(gpx.get_track_points_no())
 
         length = gpx.length_3d()
-        print('Distance: %s' % length)
+        print(f'Distance: {length}')
 
         gpx.reduce_points(2000, min_distance=10)
 
@@ -564,12 +564,12 @@ class GPXTests(mod_unittest.TestCase):
 
         moving_time, stopped_time, moving_distance, stopped_distance, max_speed = gpx.get_moving_data(stopped_speed_threshold=0.1)
         print('-----')
-        print('Length: %s' % length)
-        print('Moving time: {} ({}min)'.format(moving_time, moving_time / 60.))
-        print('Stopped time: {} ({}min)'.format(stopped_time, stopped_time / 60.))
-        print('Moving distance: %s' % moving_distance)
-        print('Stopped distance: %s' % stopped_distance)
-        print('Max speed: %sm/s' % max_speed)
+        print(f'Length: {length}')
+        print(f'Moving time: {moving_time} ({moving_time / 60.}min)')
+        print(f'Stopped time: {stopped_time} ({stopped_time / 60.}min)')
+        print(f'Moving distance: {moving_distance}')
+        print(f'Stopped distance: {stopped_distance}')
+        print(f'Max speed: {max_speed}m/s')
         print('-----')
 
         # TODO: More tests and checks
@@ -1633,17 +1633,17 @@ class GPXTests(mod_unittest.TestCase):
     def test_simplify(self) -> None:
         for gpx_file in mod_os.listdir('test_files'):
             print('Parsing:', gpx_file)
-            with open('test_files/%s' % gpx_file, encoding='utf-8')as f:
+            with open(f'test_files/{gpx_file}', encoding='utf-8')as f:
                 gpx = mod_gpxpy.parse(f)
 
             length_2d_original = gpx.length_2d()
 
-            with open('test_files/%s' % gpx_file, encoding='utf-8') as f:
+            with open(f'test_files/{gpx_file}', encoding='utf-8') as f:
                 gpx = mod_gpxpy.parse(f)
             gpx.simplify(max_distance=50)
             length_2d_after_distance_50 = gpx.length_2d()
 
-            with open('test_files/%s' % gpx_file, encoding='utf-8') as f:
+            with open(f'test_files/{gpx_file}', encoding='utf-8') as f:
                 gpx = mod_gpxpy.parse(f)
             gpx.simplify(max_distance=10)
             length_2d_after_distance_10 = gpx.length_2d()
@@ -1711,7 +1711,7 @@ class GPXTests(mod_unittest.TestCase):
         for t in timestamps_without_tz:
             timestamps.append(t)
         for timestamp in timestamps:
-            print('Parsing: %s' % timestamp)
+            print(f'Parsing: {timestamp}')
             self.assertTrue(mod_gpxfield.parse_time(timestamp) is not None)
 
     def test_get_location_at(self) -> None:
@@ -2241,7 +2241,7 @@ class GPXTests(mod_unittest.TestCase):
                 self.assertTrue(elements_equal(gpx.metadata_extensions[2], ccc))
 
                 # get_dom_node function is not escaped and so fails on proper namespaces
-                #self.assertEqual(get_dom_node(dom, 'gpx/metadata/extensions/{}aaa'.format(namespace)).firstChild.nodeValue, 'bbb')
+                #self.assertEqual(get_dom_node(dom, f'gpx/metadata/extensions/{namespace}aaa').firstChild.nodeValue, 'bbb')
                 #self.assertEqual(get_dom_node(dom, 'gpx/metadata/extensions/bbb').firstChild.nodeValue, 'ccc')
                 #self.assertEqual(get_dom_node(dom, 'gpx/metadata/extensions/ccc').firstChild.nodeValue, 'ddd')
 

--- a/test.py
+++ b/test.py
@@ -702,7 +702,7 @@ class GPXTests(mod_unittest.TestCase):
                          mod_geo.haversine_distance(loc1.latitude, loc1.longitude, loc2.latitude, loc2.longitude))
 
     def test_horizontal_smooth_remove_extremes(self) -> None:
-        with open('test_files/track-with-extremes.gpx', 'r') as f:
+        with open('test_files/track-with-extremes.gpx') as f:
 
             parser = mod_parser.GPXParser(f)
 
@@ -718,7 +718,7 @@ class GPXTests(mod_unittest.TestCase):
         self.assertTrue(points_before - 2 == points_after)
 
     def test_vertical_smooth_remove_extremes(self) -> None:
-        with open('test_files/track-with-extremes.gpx', 'r') as f:
+        with open('test_files/track-with-extremes.gpx') as f:
             parser = mod_parser.GPXParser(f)
 
         gpx = parser.parse()
@@ -733,7 +733,7 @@ class GPXTests(mod_unittest.TestCase):
         self.assertTrue(points_before - 1 == points_after)
 
     def test_horizontal_and_vertical_smooth_remove_extremes(self) -> None:
-        with open('test_files/track-with-extremes.gpx', 'r') as f:
+        with open('test_files/track-with-extremes.gpx') as f:
             parser = mod_parser.GPXParser(f)
 
         gpx = parser.parse()
@@ -3198,14 +3198,14 @@ class GPXTests(mod_unittest.TestCase):
         self.assertFalse('extension' in xml)
 
     def test_extension_without_namespaces(self) -> None:
-        f = open('test_files/gpx1.1_with_extensions_without_namespaces.gpx', 'r')
+        f = open('test_files/gpx1.1_with_extensions_without_namespaces.gpx')
         gpx = mod_gpxpy.parse(f)
         self.assertEqual(2, len(gpx.waypoints[0].extensions))
         self.assertEqual("bbb", gpx.waypoints[0].extensions[0].text)
         self.assertEqual("eee", list(gpx.waypoints[0].extensions[1])[0].text.strip())
 
     def test_garmin_extension(self) -> None:
-        f = open('test_files/gpx_with_garmin_extension.gpx', 'r')
+        f = open('test_files/gpx_with_garmin_extension.gpx')
         gpx = mod_gpxpy.parse(f)
         xml = gpx.to_xml()
         self.assertTrue("<gpxtpx:TrackPointExtension>" in xml)
@@ -3283,7 +3283,7 @@ class GPXTests(mod_unittest.TestCase):
 
     def test_small_floats(self) -> None:
         """GPX 1/1 does not allow scientific notation but that is what gpxpy writes right now."""
-        f = open('test_files/track-with-small-floats.gpx', 'r')
+        f = open('test_files/track-with-small-floats.gpx')
         
 
         gpx = mod_gpxpy.parse(f)

--- a/xsd/pretty_print_schemas.py
+++ b/xsd/pretty_print_schemas.py
@@ -10,10 +10,7 @@ def get_children_by_tag_name(node: Any, tag_name: str) -> Any:
     return result
 
 def get_indented(indentation: int, string: str) -> str:
-    result = ''
-    for i in range(indentation):
-        result += '    '
-    return result + str(string) + '\n'
+    return f'{"    " * indentation}{string}\n'
 
 def parse_1_1(dom: Any) -> Any:
     root_node = dom.childNodes[0]


### PR DESCRIPTION
1. Use Python3 defaults, such as source code file encoding or reading mode for opened file
2. Log entries should not be pre-formatted, so use `log.info('hello %s', 'world')` instead of `log.info('hello %s' % 'world)`
3. Use f-strings. All updates within one commit, but all changes are self-contained within their methods/blocks and no public interfaces have been affected