### PR TITLE
Add correct versions for classifiers and badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
+![PyPI](https://img.shields.io/pypi/v/gpxpy)
+![PyPI - Python Version](https://img.shields.io/pypi/pyversions/gpxpy)
 [![Build Status](https://travis-ci.org/tkrajina/gpxpy.svg?branch=master)](https://travis-ci.org/tkrajina/gpxpy)
 [![Coverage Status](https://coveralls.io/repos/github/tkrajina/gpxpy/badge.svg?branch=master)](https://coveralls.io/github/tkrajina/gpxpy?branch=master)
+[![GitHub license](https://img.shields.io/github/license/tkrajina/gpxpy)](https://github.com/tkrajina/gpxpy/blob/dev/LICENSE.txt)
 
 # gpxpy -- GPX file parser
 

--- a/setup.py
+++ b/setup.py
@@ -43,6 +43,7 @@ setup(
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
     ],
     scripts=['gpxinfo'],
 )


### PR DESCRIPTION
Add Python 3.9 to PyPI classifiers
Show the gpxpy version, Python versions, and license as badges in the `README.md` file.
