### PR TITLE
Avoid using strftime in format_time

### DIFF
--- a/gpxpy/gpxfield.py
+++ b/gpxpy/gpxfield.py
@@ -89,7 +89,13 @@ def parse_time(string: str) -> Optional[mod_datetime.datetime]:
 
 
 def format_time(time: mod_datetime.datetime) -> str:
-    return time.isoformat().replace('+00:00', 'Z')
+    offset = time.utcoffset()
+    if not offset:
+        tz = 'Z'
+    else:
+        tz = time.strftime('%z')
+    isofmt_time = time.replace(tzinfo=None).isoformat()
+    return ''.join((isofmt_time, tz))
 
 
 
@@ -118,7 +124,10 @@ class TimeConverter:
             return None
 
     def to_string(self, time: Optional[mod_datetime.datetime]) -> Optional[str]:
-        return format_time(time) if time else None
+        if time:
+            return format_time(time)
+        else:
+            return None
 
 
 INT_TYPE = IntConverter()

--- a/gpxpy/gpxfield.py
+++ b/gpxpy/gpxfield.py
@@ -89,13 +89,7 @@ def parse_time(string: str) -> Optional[mod_datetime.datetime]:
 
 
 def format_time(time: mod_datetime.datetime) -> str:
-    offset = time.utcoffset()
-    if not offset:
-        tz = 'Z'
-    else:
-        tz = time.strftime('%z')
-    isofmt_time = time.replace(tzinfo=None).isoformat()
-    return ''.join((isofmt_time, tz))
+    return time.isoformat().replace('+00:00', 'Z')
 
 
 

--- a/gpxpy/gpxfield.py
+++ b/gpxpy/gpxfield.py
@@ -125,9 +125,8 @@ class TimeConverter:
 
     def to_string(self, time: Optional[mod_datetime.datetime]) -> Optional[str]:
         if time:
-            return format_time(time)
-        else:
-            return None
+            return format_time(time) if time else None
+        return None
 
 
 INT_TYPE = IntConverter()

--- a/gpxpy/gpxfield.py
+++ b/gpxpy/gpxfield.py
@@ -89,16 +89,7 @@ def parse_time(string: str) -> Optional[mod_datetime.datetime]:
 
 
 def format_time(time: mod_datetime.datetime) -> str:
-    offset = time.utcoffset()
-    if not offset:
-        tz = 'Z'
-    else:
-        tz = time.strftime('%z')
-    if time.microsecond:
-        ms = time.strftime('.%f')
-    else:
-        ms = ''
-    return ''.join((time.strftime('%Y-%m-%dT%H:%M:%S'), ms, tz))
+    return time.isoformat().replace('+00:00', 'Z')
 
 
 
@@ -127,9 +118,7 @@ class TimeConverter:
             return None
 
     def to_string(self, time: Optional[mod_datetime.datetime]) -> Optional[str]:
-        if time:
-            return format_time(time) if time else None
-        return None
+        return format_time(time) if time else None
 
 
 INT_TYPE = IntConverter()

--- a/gpxpy/gpxfield.py
+++ b/gpxpy/gpxfield.py
@@ -89,7 +89,13 @@ def parse_time(string: str) -> Optional[mod_datetime.datetime]:
 
 
 def format_time(time: mod_datetime.datetime) -> str:
-    return time.isoformat().replace('+00:00', 'Z')
+    offset = time.utcoffset()
+    if not offset:
+        tz = 'Z'
+    else:
+        tz = time.strftime('%z')
+    isofmt_time = time.replace(tzinfo=None).isoformat()
+    return ''.join((isofmt_time, tz))
 
 
 

--- a/gpxpy/gpxfield.py
+++ b/gpxpy/gpxfield.py
@@ -118,9 +118,7 @@ class TimeConverter:
             return None
 
     def to_string(self, time: Optional[mod_datetime.datetime]) -> Optional[str]:
-        if time:
-            return format_time(time) if time else None
-        return None
+        return format_time(time) if time else None
 
 
 INT_TYPE = IntConverter()

--- a/gpxpy/utils.py
+++ b/gpxpy/utils.py
@@ -41,7 +41,7 @@ def to_xml(tag: str, attributes: Any=None, content: Any=None, default: Any=None,
         else:
             result.append(make_str(f'>{content}</{tag}>'))
 
-    return ''.join(result)
+    return make_str(''.join(result))
 
 
 def is_numeric(object: Any) -> bool:

--- a/gpxpy/utils.py
+++ b/gpxpy/utils.py
@@ -41,7 +41,7 @@ def to_xml(tag: str, attributes: Any=None, content: Any=None, default: Any=None,
         else:
             result.append(make_str(f'>{content}</{tag}>'))
 
-    return make_str(''.join(result))
+    return ''.join(result)
 
 
 def is_numeric(object: Any) -> bool:

--- a/test.py
+++ b/test.py
@@ -1714,6 +1714,25 @@ class GPXTests(mod_unittest.TestCase):
             print('Parsing: %s' % timestamp)
             self.assertTrue(mod_gpxfield.parse_time(timestamp) is not None)
 
+    def test_format_time(self) -> None:
+        tz1 = mod_datetime.timezone(mod_datetime.timedelta(hours=2), )
+        tz2 = mod_datetime.timezone.utc
+        # pase_time() doesn't work correctly for tz-unaware datetimes.
+        times1 = [mod_datetime.datetime(*t) for t in [#(2001, 10, 26, 21, 32, 52),
+                                                      (2001, 10, 26, 21, 32, 52, 0, tz1),
+                                                      (2001, 10, 26, 19, 32, 52, 0, tz2),
+                                                      #(2001, 10, 26, 21, 32, 52, 126790),
+                                                      (2001, 10, 26, 21, 32, 52, 126790, tz1),
+                                                      (2001, 10, 26, 19, 32, 52, 126790, tz2)]]
+        times2 = []
+        for t in times1:
+            str_t = mod_gpxfield.format_time(t)
+            print(str_t)
+            t2 = mod_gpxfield.parse_time(str_t)
+            print(t2)
+            times2.append(t2)
+        self.assertEqual(times1, times2)
+
     def test_get_location_at(self) -> None:
         gpx = mod_gpx.GPX()
         gpx.tracks.append(mod_gpx.GPXTrack())

--- a/test.py
+++ b/test.py
@@ -1714,6 +1714,16 @@ class GPXTests(mod_unittest.TestCase):
             print('Parsing: %s' % timestamp)
             self.assertTrue(mod_gpxfield.parse_time(timestamp) is not None)
 
+    def test_dst_in_SimpleTZ(self) -> None:
+        # No DST in UTC times.
+        timestamps = ['2001-10-26T19:32:52Z',
+                      '2001-10-26T19:32:52+0000',
+                      '2001-10-26T19:32:52+00:00']
+        for timestamp in timestamps:
+            daylight_saving_time = mod_gpxfield.parse_time(timestamp).dst()
+            print(f'Testing: {timestamp}, dst = {daylight_saving_time}')
+            self.assertTrue(daylight_saving_time in {None, mod_datetime.timedelta(0)})
+
     def test_format_time(self) -> None:
         tz1 = mod_datetime.timezone(mod_datetime.timedelta(hours=2), )
         tz2 = mod_datetime.timezone.utc


### PR DESCRIPTION
Issue #225

To reduce the processing time and to make the code simple, .isoformat() is used instead of strftime.

TZ format is changed from '+/-HHMM' to '+/-HH:MM'.  Both of the formats are allowed in the standard.