### PR TITLE
docs: fix a few simple typos

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,7 +21,7 @@ Please include tests for new features. Tests or documentation without bug fixes 
 - Run the test suite on both Python 2.x and 3.x. You can enable [Travis CI](https://travis-ci.org/profile/) on your repo to catch test failures prior to the pull request, and [Coveralls](https://coveralls.io) to see if the changed code is covered by tests.
 - Create a pull request to pull the changes from your branch to the gpxpy master.
 
-If you plan a big refactory, open an inssue for discussion before starting it.
+If you plan a big refactory, open an issue for discussion before starting it.
 
 ### Guidelines
 

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ The GPX version is automatically determined when parsing by reading the version 
 
 ## GPX max speed
 
-Gpxpy is a GPX parser and by using it you have acess to all the data from the original GPX file. The additional methods to calculate stats have some additional heuristics to remove common GPS errors. For example, to calculate `max_speed` it removes the top `5%` of speeds and points with nonstandard distance (those are usually GPS errors).
+Gpxpy is a GPX parser and by using it you have access to all the data from the original GPX file. The additional methods to calculate stats have some additional heuristics to remove common GPS errors. For example, to calculate `max_speed` it removes the top `5%` of speeds and points with nonstandard distance (those are usually GPS errors).
 
 "Raw" max speed can be calculated with:
 

--- a/gpxpy/gpx.py
+++ b/gpxpy/gpx.py
@@ -836,7 +836,7 @@ class GPXTrackSegment:
         self.points += track_segment.points
 
     def remove_point(self, point_no: int) -> None:
-        """ Removes a point specificed by index from the segment """
+        """ Removes a point specified by index from the segment """
         if point_no < 0 or point_no >= len(self.points):
             return
 
@@ -1562,7 +1562,7 @@ class GPXTrack:
         point : GPXTrackPoint
             Point in the track
         segment_no : integer
-            Index of segment containint point. This is suppressed if only_points
+            Index of segment containing point. This is suppressed if only_points
             is True.
         point_no : integer
             Index of point. This is suppressed if only_points is True.
@@ -2309,10 +2309,10 @@ class GPX:
         point : GPXTrackPoint
             Point in the track
         track_no : integer
-            Index of track containint point. This is suppressed if only_points
+            Index of track containing point. This is suppressed if only_points
             is True.
         segment_no : integer
-            Index of segment containint point. This is suppressed if only_points
+            Index of segment containing point. This is suppressed if only_points
             is True.
         point_no : integer
             Index of point. This is suppressed if only_points is True.


### PR DESCRIPTION
There are small typos in:
- CONTRIBUTING.md
- README.md
- gpxpy/gpx.py

Fixes:
- Should read `containing` rather than `containint`.
- Should read `specified` rather than `specificed`.
- Should read `issue` rather than `inssue`.
- Should read `access` rather than `acess`.

Closes #235