### PR TITLE
Use python-build to also make wheels

### DIFF
--- a/makefile
+++ b/makefile
@@ -25,7 +25,9 @@ check-all-committed:
 .PHONY: pypi-upload
 pypi-upload: check-all-committed test
 	rm -Rf dist/*
-	python setup.py sdist
+	python3 -m build --help > /dev/null 2>&1 || python3 -m pip install build
+	python3 -m build
+	twine check dist/*
 	twine upload dist/*
 
 .PHONY: ctags


### PR DESCRIPTION
Fixes https://github.com/tkrajina/gpxpy/issues/237.

Currently, gpxpy is distributed on PyPI only as a sdist:

* https://pypi.org/project/gpxpy/1.5.0/#files

Please could you also distribute a wheel? It makes installation faster. More info: 

* https://pythonwheels.com/

This PR updates the `makefile` to create both an sdist and wheel using https://github.com/pypa/build, and upload both.

This solves another problem too, calling `setup.py` directly is deprecated by setuptools:

* https://blog.ganssle.io/articles/2021/10/setup-py-deprecated.html
