### PR TITLE
Fixing issue in get_bounds with one bound being equal to zero

### DIFF
--- a/gpxpy/gpx.py
+++ b/gpxpy/gpx.py
@@ -985,7 +985,7 @@ class GPXTrackSegment:
             if max_lon is None or point.longitude > max_lon:
                 max_lon = point.longitude
 
-        if min_lat and max_lat and min_lon and max_lon:
+        if not any([b is None for b in [min_lat, max_lat, min_lon, max_lon]]):
             return GPXBounds(min_lat, max_lat, min_lon, max_lon)
         return None
 

--- a/test.py
+++ b/test.py
@@ -850,6 +850,24 @@ class GPXTests(mod_unittest.TestCase):
         self.assertEqual(gpx.bounds.min_longitude, -100) # type: ignore
         self.assertEqual(gpx.bounds.max_longitude, 100) # type: ignore
 
+    def test_bounds_zero(self) -> None:
+        gpx = mod_gpx.GPX()
+
+        track = mod_gpx.GPXTrack()
+
+        segment_1 = mod_gpx.GPXTrackSegment()
+        segment_1.points.append(mod_gpx.GPXTrackPoint(latitude=0, longitude=1))
+        segment_1.points.append(mod_gpx.GPXTrackPoint(latitude=1, longitude=1))
+        segment_1.points.append(mod_gpx.GPXTrackPoint(latitude=2, longitude=2))
+        track.segments.append(segment_1)
+        gpx.tracks.append(track)
+        
+        bounds = gpx.get_bounds()
+        self.assertEqual(bounds.min_latitude, 0) # type: ignore
+        self.assertEqual(bounds.max_latitude, 2) # type: ignore
+        self.assertEqual(bounds.min_longitude, 1) # type: ignore
+        self.assertEqual(bounds.max_longitude, 2) # type: ignore
+
     def test_bounds_xml(self) -> None:
         track = mod_gpx.GPX()
         track.bounds = mod_gpx.GPXBounds(1, 2, 3, 4)


### PR DESCRIPTION
When using the get_bounds method on a track which has bounds falling on latitude or longitude zero, the method returns None instead of the correct bound object. See test added in PR, which would fail in current version of `gpxpy`.