### PR TITLE
Use type alias for dict

### DIFF
--- a/gpxpy/gpxfield.py
+++ b/gpxpy/gpxfield.py
@@ -67,7 +67,7 @@ class SimpleTZ(mod_datetime.tzinfo):
     def __copy__(self) -> mod_datetime.tzinfo:
         return self.__deepcopy__()
 
-    def __deepcopy__(self, memodict: Optional[dict[Any, Any]]={}) -> mod_datetime.tzinfo:
+    def __deepcopy__(self, memodict: Optional[Dict[Any, Any]]={}) -> mod_datetime.tzinfo:
         return self.__class__(self.tzname(None))
 
     def __repr__(self) -> str:


### PR DESCRIPTION
Fixes TypeError on python <3.9

```python
  ...
    import gpxpy
  File "/opt/hostedtoolcache/Python/3.8.18/x64/lib/python3.8/site-packages/gpxpy/__init__.py", line 17, in <module>
    from . import gpx as mod_gpx
  File "/opt/hostedtoolcache/Python/3.8.18/x64/lib/python3.8/site-packages/gpxpy/gpx.py", line 27, in <module>
    from . import gpxfield as mod_gpxfield
  File "/opt/hostedtoolcache/Python/3.8.18/x64/lib/python3.8/site-packages/gpxpy/gpxfield.py", line 36, in <module>
    class SimpleTZ(mod_datetime.tzinfo):
  File "/opt/hostedtoolcache/Python/3.8.18/x64/lib/python3.8/site-packages/gpxpy/gpxfield.py", line 70, in SimpleTZ
    def __deepcopy__(self, memodict: Optional[dict[Any, Any]]={}) -> mod_datetime.tzinfo:
TypeError: 'type' object is not subscriptable
```

Fixes #266 