### PR TITLE
Bug fix: 'Name error' exception occurs when from_start_to_end does not exist.

### DIFF
--- a/gpxpy/gpx.py
+++ b/gpxpy/gpx.py
@@ -1110,6 +1110,8 @@ class GPXTrackSegment:
         from_start_to_end = None
         if dist:
             from_start_to_end = distances[-1] + dist
+        else:
+            from_start_to_end = None
 
         assert len(interval) == len(distances)
 


### PR DESCRIPTION
Bug fix: 'Name error' exception occurs when from_start_to_end does not exist.