### PR TITLE
Add support for Python 3.9-3.14

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,16 +15,18 @@ jobs:
     runs-on: ubuntu-latest
 
     strategy:
+      fail-fast: false
       matrix:
-        python-version: [ "3.12", "3.11", "3.10", "3.9", "3.8" ]
+        python-version: [ "3.14", "3.13", "3.12", "3.11", "3.10", "3.9", "3.8" ]
     steps:
     - name: Checkout code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v5
 
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
+        allow-prereleases: true
 
     - name: Run tests
       run: make test

--- a/setup.py
+++ b/setup.py
@@ -43,6 +43,12 @@ setup(
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
+        "Programming Language :: Python :: 3.12",
+        "Programming Language :: Python :: 3.13",
+        "Programming Language :: Python :: 3.14",
     ],
     scripts=['gpxinfo'],
 )


### PR DESCRIPTION
The Python 3.14 release candidate is out. 🚀 

The 3.14 release manager (👋 hi, that's me!) [said](https://discuss.python.org/t/python-3-14-0rc2-and-3-13-7-are-go/102403):

> ## Call to action
> 
> We **_strongly encourage_** maintainers of third-party Python projects to prepare their projects for 3.14 during this phase, and publish Python 3.14 wheels on PyPI to be ready for the final release of 3.14.0, and to help other projects do their own testing. Any binary wheels built against Python 3.14.0rc1 **_will work_** with future versions of Python 3.14. As always, report any issues to [the Python bug tracker](https://github.com/python/cpython/issues).

This PR adds 3.13 and 3.14 to the CI, and the Trove classifiers for 3.9-3.14.

It also updates GitHub Actions.

---

Separately, I recommend dropping support for EOL Python 3.6-3.8, but especially for 3.6-3.7 which are no longer tested on CI.