### PR TITLE
fix: preserve negative timezone offsets when cloning gpx

### DIFF
--- a/gpxpy/gpxfield.py
+++ b/gpxpy/gpxfield.py
@@ -63,7 +63,9 @@ class SimpleTZ(mod_datetime.tzinfo):
     def tzname(self, dt: Optional[mod_datetime.datetime]) -> str:
         if self.offset == 0:
             return 'Z'
-        return f'{self.offset // 60:02}:{self.offset % 60:02}'
+        sign = '-' if self.offset < 0 else '+'
+        offset = abs(self.offset)
+        return f'{sign}{offset // 60:02}:{offset % 60:02}'
 
     def __copy__(self) -> mod_datetime.tzinfo:
         return self.__deepcopy__()

--- a/test.py
+++ b/test.py
@@ -3127,6 +3127,18 @@ class GPXTests(mod_unittest.TestCase):
         self.assertTrue(t_stamp + "+01:00" in reparsed.to_xml() or t_stamp + "+0100" in reparsed.to_xml())
         self.assertTrue(reparsed.tracks[0].segments[0].points[0].time.tzinfo) # type: ignore
 
+    def test_deepcopy_negative_simpletz(self) -> None:
+        xml = '<?xml version="1.0" encoding="UTF-8"?>\n'
+        xml += '<gpx>\n<trk>\n<trkseg>\n'
+        xml += '<trkpt lat="1" lon="2"><time>2018-04-04T10:36:53-06:00</time></trkpt>\n'
+        xml += '</trkseg></trk></gpx>\n'
+        gpx = mod_gpxpy.parse(xml)
+        clone = gpx.clone()
+        original_time = gpx.tracks[0].segments[0].points[0].time
+        cloned_time = clone.tracks[0].segments[0].points[0].time
+        self.assertEqual(original_time, cloned_time)
+        self.assertEqual(cloned_time.utcoffset(), mod_datetime.timedelta(hours=-6)) # type: ignore
+
     def test_timestamp_with_single_digits(self) -> None:
         xml = '<?xml version="1.0" encoding="UTF-8"?>\n'
         xml += '<gpx>\n'


### PR DESCRIPTION
Fixes #190. SimpleTZ.__deepcopy__ rebuilt the tzinfo from tzname(), but tzname() emitted a malformed string for negative offsets (e.g. '-6:00') that SimpleTZ.__init__ parsed back to a zero offset, so clone() silently dropped non-UTC timezones. This zero-pads the hour and adds the sign so tzname() round-trips, with a regression test.